### PR TITLE
[ververica] include parent name into subprojects jar files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,6 +138,9 @@ subprojects {
 
     shadowJar {
         configurations = [project.configurations.flinkShadowJar]
+        if (project.parent != rootProject) {
+            archiveBaseName.set("${project.parent.name}-${project.name}")
+        }
     }
 
     assemble.dependsOn(shadowJar)


### PR DESCRIPTION
This will make the troubleshooting projects build jar files like `troubleshooting-introduction-1.11-SNAPSHOT-all.jar`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ververica/flink-training/4)
<!-- Reviewable:end -->
