### PR TITLE
add state-migration exercise

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,14 +20,14 @@ plugins {
 }
 
 subprojects {
-    if (project == project(":troubleshooting")) {
+    if (project == project(":troubleshooting") || project == project(":troubleshooting:state-migration")) {
         // this is just an additional grouping layer, not a project!
         return
     }
 
     apply plugin: 'java'
     apply plugin: 'scala' // optional; uncomment if needed
-    if (project != project(":common") && project != project(":troubleshooting:common")) {
+    if (project != project(":common") && project != project(":troubleshooting:common") && project != project(":troubleshooting:state-migration:common")) {
         apply plugin: 'application'
     }
     apply plugin: 'com.github.johnrengelman.shadow'

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -49,6 +49,19 @@ under the License.
 		files="(.*)troubleshooting[/\\]object-reuse[/\\](.*)com[/\\]ververica[/\\]flink[/\\]training[/\\]solutions[/\\]immutable[/\\](ExtendedMeasurement|Location|MeasurementValue|Sensor)\.java"
 		checks="MissingJavadocMethod"/>
 
+	<!-- troubleshooting/state-migration -->
+	<suppress
+		files="(.*)troubleshooting[/\\]state-migration[/\\](.*)com[/\\]ververica[/\\]flink[/\\]training[/\\]exercises[/\\](MeasurementAggregationReport)\.java"
+		checks="MissingJavadocMethod"/>
+	<suppress
+		files="(.*)troubleshooting[/\\]state-migration[/\\](.*)com[/\\]ververica[/\\]flink[/\\]training[/\\]exercises[/\\]custom[/\\](AggregatedSensorStatistics)\.java"
+		checks="MissingJavadocMethod"/>
+
+	<!-- Avro-generated files -->
+	<suppress
+		files="(.*)generated-(.*)-avro-java(.*)\.java"
+		checks=".*"/>
+
 	<suppress
 			files="(.*)test[/\\](.*)"
 			checks="MissingJavadocMethod"/>

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,6 +12,10 @@ include 'troubleshooting:common'
 include 'troubleshooting:introduction'
 include 'troubleshooting:object-reuse'
 include 'troubleshooting:external-enrichment'
+include 'troubleshooting:state-migration:common'
+include 'troubleshooting:state-migration:exercise'
+include 'troubleshooting:state-migration:solution'
+include 'troubleshooting:state-migration:solution-custom-to-avro'
 
 // CI=true, TRAVIS=true, CONTINUOUS_INTEGRATION=true set automatically during Travis execution
 // see https://docs.travis-ci.com/user/environment-variables#default-environment-variables

--- a/troubleshooting/README.md
+++ b/troubleshooting/README.md
@@ -4,6 +4,7 @@
 1. Advanced
    1. [External Enrichment](external-enrichment)
    1. [Object Reuse](object-reuse)
+   1. [State Migration](state-migration)
 
 -----
 

--- a/troubleshooting/common/src/main/java/com/ververica/flink/training/common/SourceUtils.java
+++ b/troubleshooting/common/src/main/java/com/ververica/flink/training/common/SourceUtils.java
@@ -12,6 +12,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
@@ -32,6 +33,14 @@ public class SourceUtils {
 		List<byte[]> serializedMeasurements = createSerializedMeasurements();
 		return new FakeKafkaSource(RANDOM_SEED, FAILURE_RATE, IDLE_PARTITIONS,
 				serializedMeasurements);
+	}
+
+	/**
+	 * Creates a source that resembles a failure-free Kafka source but reads from memory.
+	 */
+	public static FakeKafkaSource createFailureFreeFakeKafkaSource() {
+		List<byte[]> serializedMeasurements = createSerializedMeasurements();
+		return new FakeKafkaSource(RANDOM_SEED, 0.0f, Collections.emptyList(), serializedMeasurements);
 	}
 
 	private static List<byte[]> createSerializedMeasurements() {

--- a/troubleshooting/state-migration/README.md
+++ b/troubleshooting/state-migration/README.md
@@ -1,0 +1,7 @@
+# Lab: Advanced Tuning & Troubleshooting: State Migration
+
+...
+
+-----
+
+[**Back to Tuning & Troubleshooting Labs Overview**](../README.md)

--- a/troubleshooting/state-migration/build.gradle
+++ b/troubleshooting/state-migration/build.gradle
@@ -1,0 +1,3 @@
+subprojects {
+    group = 'com.ververica.flink.training.troubleshooting.state-migration'
+}

--- a/troubleshooting/state-migration/common/build.gradle
+++ b/troubleshooting/state-migration/common/build.gradle
@@ -1,0 +1,10 @@
+plugins {
+    id 'java-library'
+}
+
+dependencies {
+    api project(":troubleshooting:common")
+
+    api "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    api "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+}

--- a/troubleshooting/state-migration/common/src/main/java/com/ververica/flink/training/exercises/MeasurementAggregationReport.java
+++ b/troubleshooting/state-migration/common/src/main/java/com/ververica/flink/training/exercises/MeasurementAggregationReport.java
@@ -1,0 +1,56 @@
+package com.ververica.flink.training.exercises;
+
+/**
+ * Type for reporting aggregate results.
+ */
+public class MeasurementAggregationReport {
+	private int sensorId;
+	private long count;
+	private double average;
+	private long latestUpdate;
+
+	public MeasurementAggregationReport() {
+	}
+
+	public int getSensorId() {
+		return sensorId;
+	}
+
+	public void setSensorId(int sensorId) {
+		this.sensorId = sensorId;
+	}
+
+	public long getCount() {
+		return count;
+	}
+
+	public void setCount(long count) {
+		this.count = count;
+	}
+
+	public double getAverage() {
+		return average;
+	}
+
+	public void setAverage(double average) {
+		this.average = average;
+	}
+
+	public long getLatestUpdate() {
+		return latestUpdate;
+	}
+
+	public void setLatestUpdate(long latestUpdate) {
+		this.latestUpdate = latestUpdate;
+	}
+
+	@Override
+	public String toString() {
+		return "MeasurementAggregationReport{" +
+				"sensorId=" + sensorId +
+				", count=" + count +
+				", average=" + average +
+				", latestUpdate=" + latestUpdate +
+				'}';
+	}
+}

--- a/troubleshooting/state-migration/common/src/main/java/com/ververica/flink/training/exercises/MeasurementDeserializer.java
+++ b/troubleshooting/state-migration/common/src/main/java/com/ververica/flink/training/exercises/MeasurementDeserializer.java
@@ -1,0 +1,44 @@
+package com.ververica.flink.training.exercises;
+
+import org.apache.flink.api.common.functions.RichFlatMapFunction;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Collector;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ververica.flink.training.common.DoNotChangeThis;
+import com.ververica.flink.training.common.FakeKafkaRecord;
+import com.ververica.flink.training.common.Measurement;
+
+import java.io.IOException;
+
+/**
+ * Deserializes {@link FakeKafkaRecord} into {@link Measurement} objects, ignoring deserialization
+ * failures.
+ */
+@DoNotChangeThis
+public class MeasurementDeserializer extends RichFlatMapFunction<FakeKafkaRecord, Measurement> {
+
+	private static final long serialVersionUID = -5805258552949837150L;
+
+	private transient ObjectMapper mapper;
+
+	@Override
+	public void open(final Configuration parameters) throws Exception {
+		super.open(parameters);
+		mapper = new ObjectMapper();
+		mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+	}
+
+	private Measurement deserialize(final byte[] bytes) throws IOException {
+		return mapper.readValue(bytes, Measurement.class);
+	}
+
+	@Override
+	public void flatMap(final FakeKafkaRecord kafkaRecord, final Collector<Measurement> out) {
+		try {
+			out.collect(deserialize(kafkaRecord.getValue()));
+		} catch (IOException ignored) {
+		}
+	}
+}

--- a/troubleshooting/state-migration/common/src/main/java/com/ververica/flink/training/exercises/SensorAggregationProcessingBase.java
+++ b/troubleshooting/state-migration/common/src/main/java/com/ververica/flink/training/exercises/SensorAggregationProcessingBase.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.flink.training.exercises;
+
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
+
+import com.ververica.flink.training.common.Measurement;
+
+public abstract class SensorAggregationProcessingBase extends
+		KeyedProcessFunction<Integer, Measurement, MeasurementAggregationReport> {
+	private static final long serialVersionUID = 5841581588188443035L;
+
+	/**
+	 * Gets the name of the state serializer that is being used.
+	 */
+	public abstract String getStateSerializerName();
+}

--- a/troubleshooting/state-migration/common/src/main/java/com/ververica/flink/training/exercises/StateMigrationJobBase.java
+++ b/troubleshooting/state-migration/common/src/main/java/com/ververica/flink/training/exercises/StateMigrationJobBase.java
@@ -1,0 +1,94 @@
+package com.ververica.flink.training.exercises;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.java.utils.ParameterTool;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.util.OutputTag;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ververica.flink.training.common.DoNotChangeThis;
+import com.ververica.flink.training.common.EnvironmentUtils;
+import com.ververica.flink.training.common.FakeKafkaRecord;
+import com.ververica.flink.training.common.Measurement;
+import com.ververica.flink.training.common.SourceUtils;
+
+import java.time.Duration;
+
+@DoNotChangeThis
+public class StateMigrationJobBase {
+	public static final OutputTag<Measurement> LATE_DATA_TAG =
+			new OutputTag<Measurement>("late-data") {
+				private static final long serialVersionUID = 33513631677208956L;
+			};
+
+	protected static void createAndExecuteJob(
+			String[] args,
+			SensorAggregationProcessingBase keyedProcessFunction)
+			throws Exception {
+		ParameterTool parameters = ParameterTool.fromArgs(args);
+
+		StreamExecutionEnvironment env = EnvironmentUtils.createConfiguredEnvironment(parameters);
+
+		//Time Characteristics
+		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+
+		//Checkpointing Configuration
+		env.enableCheckpointing(5000);
+		env.getCheckpointConfig().setMinPauseBetweenCheckpoints(4000);
+
+		DataStream<Measurement> sourceStream = env
+				.addSource(SourceUtils.createFailureFreeFakeKafkaSource()).name("FakeKafkaSource")
+				.assignTimestampsAndWatermarks(
+						WatermarkStrategy.<FakeKafkaRecord>forBoundedOutOfOrderness(
+								Duration.ofMillis(250))
+								.withTimestampAssigner(
+										(element, timestamp) -> element.getTimestamp())
+				)
+				.map(new MeasurementDeserializer())
+				.name("Deserialization");
+
+		SingleOutputStreamOperator<MeasurementAggregationReport> aggregatedPerSensor = sourceStream
+				.keyBy(Measurement::getSensorId)
+				.process(keyedProcessFunction)
+				.name("AggregatePerSensor (" + keyedProcessFunction.getStateSerializerName() + ")")
+				.uid("AggregatePerSensor");
+
+		aggregatedPerSensor.addSink(new DiscardingSink<>()).name("NormalOutput")
+				.disableChaining();
+		aggregatedPerSensor.getSideOutput(LATE_DATA_TAG).addSink(new DiscardingSink<>())
+				.name("LateDataSink").disableChaining();
+
+		env.execute();
+	}
+
+	/**
+	 * Deserializes the JSON Kafka message.
+	 */
+	public static class MeasurementDeserializer extends
+			RichMapFunction<FakeKafkaRecord, Measurement> {
+		private static final long serialVersionUID = 1L;
+
+		private transient ObjectMapper mapper;
+
+		@Override
+		public void open(final Configuration parameters) throws Exception {
+			super.open(parameters);
+			mapper = new ObjectMapper();
+			mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+		}
+
+		@Override
+		public Measurement map(FakeKafkaRecord kafkaRecord) throws Exception {
+			return mapper.readValue(kafkaRecord.getValue(), Measurement.class);
+		}
+
+	}
+
+}

--- a/troubleshooting/state-migration/common/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerBase.java
+++ b/troubleshooting/state-migration/common/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerBase.java
@@ -1,0 +1,66 @@
+package com.ververica.flink.training.exercises.custom;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import com.ververica.flink.training.common.DoNotChangeThis;
+
+import java.io.IOException;
+
+/**
+ * Custom serializer base class providing some default implementations for convenience.
+ */
+@DoNotChangeThis
+public abstract class AggregatedSensorStatisticsSerializerBase<T> extends
+		TypeSerializer<T> {
+	private static final long serialVersionUID = -6967834481356870922L;
+
+	@Override
+	public boolean isImmutableType() {
+		return false;
+	}
+
+	@Override
+	public T deserialize(
+			T reuse, DataInputView source) throws IOException {
+		return deserialize(source);
+	}
+
+	@Override
+	public T copy(T from, T reuse) {
+		return copy(from);
+	}
+
+	@Override
+	public void copy(DataInputView source, DataOutputView target) throws IOException {
+		serialize(deserialize(source), target);
+	}
+
+	@Override
+	public int getLength() {
+		return -1;
+	}
+
+	@Override
+	public TypeSerializer<T> duplicate() {
+		return this;
+	}
+
+	@Override
+	public int hashCode() {
+		return this.getClass().hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof AggregatedSensorStatisticsSerializerBase) {
+			AggregatedSensorStatisticsSerializerBase<?> other =
+					(AggregatedSensorStatisticsSerializerBase<?>) obj;
+
+			return other.getClass().equals(getClass());
+		} else {
+			return false;
+		}
+	}
+}

--- a/troubleshooting/state-migration/exercise/build.gradle
+++ b/troubleshooting/state-migration/exercise/build.gradle
@@ -1,0 +1,25 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.16.0"
+    }
+}
+apply plugin: "com.commercehub.gradle.plugin.avro"
+
+mainClassName = 'com.ververica.flink.training.exercises.TroubledStreamingJob'
+
+dependencies {
+    flinkShadowJar "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    flinkShadowJar "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+
+    flinkShadowJar "org.apache.flink:flink-avro:${flinkVersion}"
+
+    implementation project(path: ':troubleshooting:state-migration:common')
+    // transitive dependencies for flinkShadowJar need to be defined above
+    // (the alternative of using configuration: 'shadow' does not work there because that adds a dependency on
+    // the jar file, not the sources)
+    flinkShadowJar project(path: ':troubleshooting:common', transitive: false)
+    flinkShadowJar project(path: ':troubleshooting:state-migration:common', transitive: false)
+}

--- a/troubleshooting/state-migration/exercise/src/main/avro/AggregatedSensorStatistics.avsc
+++ b/troubleshooting/state-migration/exercise/src/main/avro/AggregatedSensorStatistics.avsc
@@ -1,0 +1,20 @@
+{"namespace": "com.ververica.training.statemigration.avro",
+ "type": "record",
+ "name": "AggregatedSensorStatistics",
+ "fields": [
+     {
+     "name": "sensorId",
+     "type": "int"
+     },
+     {
+     "name": "count",
+     "type": "long",
+     "default": 0
+     },
+     {
+     "name": "lastUpdate",
+     "type": "long",
+     "default": 0
+     }
+ ]
+}

--- a/troubleshooting/state-migration/exercise/src/main/java/com/ververica/flink/training/exercises/avro/SensorAggregationProcessing.java
+++ b/troubleshooting/state-migration/exercise/src/main/java/com/ververica/flink/training/exercises/avro/SensorAggregationProcessing.java
@@ -1,0 +1,80 @@
+package com.ververica.flink.training.exercises.avro;
+
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Collector;
+
+import com.ververica.flink.training.common.Measurement;
+import com.ververica.flink.training.exercises.MeasurementAggregationReport;
+import com.ververica.flink.training.exercises.SensorAggregationProcessingBase;
+import com.ververica.flink.training.exercises.StateMigrationJobBase;
+import com.ververica.training.statemigration.avro.AggregatedSensorStatistics;
+
+/**
+ * Process function to report aggregated sensor statistics using Avro-serialized state.
+ */
+public class SensorAggregationProcessing extends SensorAggregationProcessingBase {
+
+	private static final int REPORTING_INTERVAL = 60_000;
+
+	private static final long serialVersionUID = 4123696380484855346L;
+
+	private transient ValueState<AggregatedSensorStatistics> aggregationState;
+
+	@Override
+	public void processElement(
+			Measurement measurement,
+			Context ctx,
+			Collector<MeasurementAggregationReport> out) throws Exception {
+		if (ctx.timestamp() > ctx.timerService().currentWatermark()) {
+			AggregatedSensorStatistics currentStats = aggregationState.value();
+			if (currentStats == null) {
+				currentStats = AggregatedSensorStatistics.newBuilder()
+						.setSensorId(measurement.getSensorId())
+						.build();
+			}
+			currentStats.setCount(currentStats.getCount() + 1);
+
+			// emit once per minute
+			long reportingTime = (ctx.timestamp() / REPORTING_INTERVAL) * REPORTING_INTERVAL;
+			if (reportingTime > ctx.timerService().currentWatermark()) {
+				ctx.timerService().registerEventTimeTimer(reportingTime);
+			}
+
+			aggregationState.update(currentStats);
+		} else {
+			ctx.output(StateMigrationJobBase.LATE_DATA_TAG, measurement);
+		}
+	}
+
+	@Override
+	public void onTimer(
+			long timestamp,
+			OnTimerContext ctx,
+			Collector<MeasurementAggregationReport> out) throws Exception {
+		AggregatedSensorStatistics currentStats = aggregationState.value();
+		currentStats.setLastUpdate(ctx.timestamp());
+
+		MeasurementAggregationReport report = new MeasurementAggregationReport();
+		report.setSensorId(currentStats.getSensorId());
+		report.setCount(currentStats.getCount());
+		report.setLatestUpdate(currentStats.getLastUpdate());
+
+		out.collect(report);
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		super.open(parameters);
+
+		final ValueStateDescriptor<AggregatedSensorStatistics> aggregationStateDesc =
+				new ValueStateDescriptor<>("aggregationStats", AggregatedSensorStatistics.class);
+		aggregationState = getRuntimeContext().getState(aggregationStateDesc);
+	}
+
+	@Override
+	public String getStateSerializerName() {
+		return "avro v1";
+	}
+}

--- a/troubleshooting/state-migration/exercise/src/main/java/com/ververica/flink/training/exercises/avro/StateMigrationJob.java
+++ b/troubleshooting/state-migration/exercise/src/main/java/com/ververica/flink/training/exercises/avro/StateMigrationJob.java
@@ -1,0 +1,20 @@
+package com.ververica.flink.training.exercises.avro;
+
+import com.ververica.flink.training.common.DoNotChangeThis;
+import com.ververica.flink.training.exercises.StateMigrationJobBase;
+
+/**
+ * State migration job for Avro state migration / schema evolution.
+ */
+@DoNotChangeThis
+public class StateMigrationJob extends StateMigrationJobBase {
+
+    /**
+     * Creates and starts the state migration streaming job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+     */
+	public static void main(String[] args) throws Exception {
+		createAndExecuteJob(args, new SensorAggregationProcessing());
+	}
+}

--- a/troubleshooting/state-migration/exercise/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatistics.java
+++ b/troubleshooting/state-migration/exercise/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatistics.java
@@ -1,0 +1,38 @@
+package com.ververica.flink.training.exercises.custom;
+
+/**
+ * Sensor statistics state POJO.
+ */
+public class AggregatedSensorStatistics {
+	private int sensorId;
+	private long count;
+	private long lastUpdate;
+
+	public AggregatedSensorStatistics() {
+	}
+
+	public int getSensorId() {
+		return sensorId;
+	}
+
+	public void setSensorId(int sensorId) {
+		this.sensorId = sensorId;
+	}
+
+	public long getCount() {
+		return count;
+	}
+
+	public void setCount(long count) {
+		this.count = count;
+	}
+
+	public long getLastUpdate() {
+		return lastUpdate;
+	}
+
+	public void setLastUpdate(long lastUpdate) {
+		this.lastUpdate = lastUpdate;
+	}
+
+}

--- a/troubleshooting/state-migration/exercise/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerSnapshotV1.java
+++ b/troubleshooting/state-migration/exercise/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerSnapshotV1.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.flink.training.exercises.custom;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+/**
+ * Serializer configuration snapshot for POJO and format evolution.
+ */
+public final class AggregatedSensorStatisticsSerializerSnapshotV1 implements
+		TypeSerializerSnapshot<AggregatedSensorStatistics> {
+	@Override
+	public int getCurrentVersion() {
+		return 1;
+	}
+
+	@Override
+	public TypeSerializerSchemaCompatibility<AggregatedSensorStatistics> resolveSchemaCompatibility(
+			TypeSerializer<AggregatedSensorStatistics> newSerializer) {
+		if (newSerializer instanceof AggregatedSensorStatisticsSerializerV1) {
+			return TypeSerializerSchemaCompatibility.compatibleAsIs();
+		} else {
+			return TypeSerializerSchemaCompatibility.incompatible();
+		}
+	}
+
+	@Override
+	public TypeSerializer<AggregatedSensorStatistics> restoreSerializer() {
+		return new AggregatedSensorStatisticsSerializerV1();
+	}
+
+	@Override
+	public void writeSnapshot(DataOutputView out) {
+	}
+
+	@Override
+	public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader) {
+	}
+}

--- a/troubleshooting/state-migration/exercise/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerV1.java
+++ b/troubleshooting/state-migration/exercise/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerV1.java
@@ -1,0 +1,53 @@
+package com.ververica.flink.training.exercises.custom;
+
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import java.io.IOException;
+
+public class AggregatedSensorStatisticsSerializerV1
+		extends AggregatedSensorStatisticsSerializerBase<AggregatedSensorStatistics> {
+
+	private static final long serialVersionUID = 7089080352317847665L;
+
+	@Override
+	public AggregatedSensorStatistics createInstance() {
+		return new AggregatedSensorStatistics();
+	}
+
+	@Override
+	public void serialize(AggregatedSensorStatistics record, DataOutputView target)
+			throws IOException {
+		target.writeInt(record.getSensorId());
+		target.writeLong(record.getCount());
+		target.writeLong(record.getLastUpdate());
+	}
+
+	@Override
+	public AggregatedSensorStatistics deserialize(DataInputView source) throws IOException {
+		int sensorId = source.readInt();
+		long count = source.readLong();
+		long lastUpdate = source.readLong();
+
+		AggregatedSensorStatistics result = new AggregatedSensorStatistics();
+		result.setSensorId(sensorId);
+		result.setCount(count);
+		result.setLastUpdate(lastUpdate);
+		return result;
+	}
+
+	@Override
+	public AggregatedSensorStatistics copy(AggregatedSensorStatistics from) {
+		AggregatedSensorStatistics result = new AggregatedSensorStatistics();
+		result.setSensorId(from.getSensorId());
+		result.setCount(from.getCount());
+		result.setLastUpdate(from.getLastUpdate());
+		return result;
+	}
+
+	@Override
+	public TypeSerializerSnapshot<AggregatedSensorStatistics> snapshotConfiguration() {
+		return new AggregatedSensorStatisticsSerializerSnapshotV1();
+	}
+}

--- a/troubleshooting/state-migration/exercise/src/main/java/com/ververica/flink/training/exercises/custom/SensorAggregationProcessing.java
+++ b/troubleshooting/state-migration/exercise/src/main/java/com/ververica/flink/training/exercises/custom/SensorAggregationProcessing.java
@@ -1,0 +1,79 @@
+package com.ververica.flink.training.exercises.custom;
+
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Collector;
+
+import com.ververica.flink.training.common.Measurement;
+import com.ververica.flink.training.exercises.MeasurementAggregationReport;
+import com.ververica.flink.training.exercises.SensorAggregationProcessingBase;
+import com.ververica.flink.training.exercises.StateMigrationJobBase;
+
+/**
+ * Process function to report aggregated sensor statistics using a custom serializer for its state.
+ */
+public class SensorAggregationProcessing extends SensorAggregationProcessingBase {
+
+	private static final int REPORTING_INTERVAL = 60_000;
+
+	private static final long serialVersionUID = 4123696380484855346L;
+
+	private transient ValueState<AggregatedSensorStatistics> aggregationState;
+
+	@Override
+	public void processElement(
+			Measurement measurement,
+			Context ctx,
+			Collector<MeasurementAggregationReport> out) throws Exception {
+		if (ctx.timestamp() > ctx.timerService().currentWatermark()) {
+			AggregatedSensorStatistics currentStats = aggregationState.value();
+			if (currentStats == null) {
+				currentStats = new AggregatedSensorStatistics();
+				currentStats.setSensorId(measurement.getSensorId());
+			}
+			currentStats.setCount(currentStats.getCount() + 1);
+
+			// emit once per minute
+			long reportingTime = (ctx.timestamp() / REPORTING_INTERVAL) * REPORTING_INTERVAL;
+			if (reportingTime > ctx.timerService().currentWatermark()) {
+				ctx.timerService().registerEventTimeTimer(reportingTime);
+			}
+
+			aggregationState.update(currentStats);
+		} else {
+			ctx.output(StateMigrationJobBase.LATE_DATA_TAG, measurement);
+		}
+	}
+
+	@Override
+	public void onTimer(
+			long timestamp,
+			OnTimerContext ctx,
+			Collector<MeasurementAggregationReport> out) throws Exception {
+		AggregatedSensorStatistics currentStats = aggregationState.value();
+		currentStats.setLastUpdate(ctx.timestamp());
+
+		MeasurementAggregationReport report = new MeasurementAggregationReport();
+		report.setSensorId(currentStats.getSensorId());
+		report.setCount(currentStats.getCount());
+		report.setLatestUpdate(currentStats.getLastUpdate());
+
+		out.collect(report);
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		super.open(parameters);
+
+		final ValueStateDescriptor<AggregatedSensorStatistics> aggregationStateDesc =
+				new ValueStateDescriptor<>("aggregationStats",
+						new AggregatedSensorStatisticsSerializerV1());
+		aggregationState = getRuntimeContext().getState(aggregationStateDesc);
+	}
+
+	@Override
+	public String getStateSerializerName() {
+		return "custom v1";
+	}
+}

--- a/troubleshooting/state-migration/exercise/src/main/java/com/ververica/flink/training/exercises/custom/StateMigrationJob.java
+++ b/troubleshooting/state-migration/exercise/src/main/java/com/ververica/flink/training/exercises/custom/StateMigrationJob.java
@@ -1,0 +1,20 @@
+package com.ververica.flink.training.exercises.custom;
+
+import com.ververica.flink.training.common.DoNotChangeThis;
+import com.ververica.flink.training.exercises.StateMigrationJobBase;
+
+/**
+ * State migration job for custom serializer state migration / schema evolution.
+ */
+@DoNotChangeThis
+public class StateMigrationJob extends StateMigrationJobBase {
+
+	/**
+	 * Creates and starts the state migration streaming job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+	 */
+	public static void main(String[] args) throws Exception {
+		createAndExecuteJob(args, new SensorAggregationProcessing());
+	}
+}

--- a/troubleshooting/state-migration/exercise/src/main/resources/log4j.properties
+++ b/troubleshooting/state-migration/exercise/src/main/resources/log4j.properties
@@ -1,0 +1,23 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+log4j.rootLogger=INFO, console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n

--- a/troubleshooting/state-migration/solution-custom-to-avro/build.gradle
+++ b/troubleshooting/state-migration/solution-custom-to-avro/build.gradle
@@ -1,0 +1,25 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.16.0"
+    }
+}
+apply plugin: "com.commercehub.gradle.plugin.avro"
+
+mainClassName = 'com.ververica.flink.training.exercises.TroubledStreamingJob'
+
+dependencies {
+    flinkShadowJar "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    flinkShadowJar "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+
+    flinkShadowJar "org.apache.flink:flink-avro:${flinkVersion}"
+
+    implementation project(path: ':troubleshooting:common')
+    // transitive dependencies for flinkShadowJar need to be defined above
+    // (the alternative of using configuration: 'shadow' does not work there because that adds a dependency on
+    // the jar file, not the sources)
+    flinkShadowJar project(path: ':troubleshooting:common', transitive: false)
+    flinkShadowJar project(path: ':troubleshooting:state-migration:common', transitive: false)
+}

--- a/troubleshooting/state-migration/solution-custom-to-avro/src/main/avro/AggregatedSensorStatistics.avsc
+++ b/troubleshooting/state-migration/solution-custom-to-avro/src/main/avro/AggregatedSensorStatistics.avsc
@@ -1,0 +1,25 @@
+{"namespace": "com.ververica.training.statemigration.avro",
+ "type": "record",
+ "name": "AggregatedSensorStatistics",
+ "fields": [
+     {
+     "name": "sensorId",
+     "type": "int"
+     },
+     {
+     "name": "count",
+     "type": "long",
+     "default": 0
+     },
+     {
+     "name": "sum",
+     "type": "double",
+     "default": 0.0
+     },
+     {
+     "name": "lastUpdate",
+     "type": "long",
+     "default": 0
+     }
+ ]
+}

--- a/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/avro/SensorAggregationProcessing.java
+++ b/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/avro/SensorAggregationProcessing.java
@@ -1,0 +1,82 @@
+package com.ververica.flink.training.exercises.avro;
+
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Collector;
+
+import com.ververica.flink.training.common.Measurement;
+import com.ververica.flink.training.exercises.MeasurementAggregationReport;
+import com.ververica.flink.training.exercises.SensorAggregationProcessingBase;
+import com.ververica.flink.training.exercises.StateMigrationJobBase;
+import com.ververica.training.statemigration.avro.AggregatedSensorStatistics;
+
+/**
+ * Process function to report aggregated sensor statistics using Avro-serialized state.
+ */
+public class SensorAggregationProcessing extends SensorAggregationProcessingBase {
+
+	private static final int REPORTING_INTERVAL = 60_000;
+
+	private static final long serialVersionUID = 4123696380484855346L;
+
+	private transient ValueState<AggregatedSensorStatistics> aggregationState;
+
+	@Override
+	public void processElement(
+			Measurement measurement,
+			Context ctx,
+			Collector<MeasurementAggregationReport> out) throws Exception {
+		if (ctx.timestamp() > ctx.timerService().currentWatermark()) {
+			AggregatedSensorStatistics currentStats = aggregationState.value();
+			if (currentStats == null) {
+				currentStats = AggregatedSensorStatistics.newBuilder()
+						.setSensorId(measurement.getSensorId())
+						.build();
+			}
+			currentStats.setCount(currentStats.getCount() + 1);
+			currentStats.setSum(currentStats.getSum() + measurement.getValue());
+
+			// emit once per minute
+			long reportingTime = (ctx.timestamp() / REPORTING_INTERVAL) * REPORTING_INTERVAL;
+			if (reportingTime > ctx.timerService().currentWatermark()) {
+				ctx.timerService().registerEventTimeTimer(reportingTime);
+			}
+
+			aggregationState.update(currentStats);
+		} else {
+			ctx.output(StateMigrationJobBase.LATE_DATA_TAG, measurement);
+		}
+	}
+
+	@Override
+	public void onTimer(
+			long timestamp,
+			OnTimerContext ctx,
+			Collector<MeasurementAggregationReport> out) throws Exception {
+		AggregatedSensorStatistics currentStats = aggregationState.value();
+		currentStats.setLastUpdate(ctx.timestamp());
+
+		MeasurementAggregationReport report = new MeasurementAggregationReport();
+		report.setSensorId(currentStats.getSensorId());
+		report.setCount(currentStats.getCount());
+		report.setAverage(currentStats.getSum() / (double) currentStats.getCount());
+		report.setLatestUpdate(currentStats.getLastUpdate());
+
+		out.collect(report);
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		super.open(parameters);
+
+		final ValueStateDescriptor<AggregatedSensorStatistics> aggregationStateDesc =
+				new ValueStateDescriptor<>("aggregationStats", AggregatedSensorStatistics.class);
+		aggregationState = getRuntimeContext().getState(aggregationStateDesc);
+	}
+
+	@Override
+	public String getStateSerializerName() {
+		return "avro v2";
+	}
+}

--- a/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/avro/StateMigrationJob.java
+++ b/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/avro/StateMigrationJob.java
@@ -1,0 +1,20 @@
+package com.ververica.flink.training.exercises.avro;
+
+import com.ververica.flink.training.common.DoNotChangeThis;
+import com.ververica.flink.training.exercises.StateMigrationJobBase;
+
+/**
+ * State migration job for Avro state migration / schema evolution.
+ */
+@DoNotChangeThis
+public class StateMigrationJob extends StateMigrationJobBase {
+
+    /**
+     * Creates and starts the state migration streaming job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+     */
+	public static void main(String[] args) throws Exception {
+		createAndExecuteJob(args, new SensorAggregationProcessing());
+	}
+}

--- a/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatistics.java
+++ b/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatistics.java
@@ -1,0 +1,46 @@
+package com.ververica.flink.training.exercises.custom;
+
+/**
+ * Sensor statistics state POJO.
+ */
+public class AggregatedSensorStatistics {
+	private int sensorId;
+	private long count;
+	private double sum;
+	private long lastUpdate;
+
+	public AggregatedSensorStatistics() {
+	}
+
+	public int getSensorId() {
+		return sensorId;
+	}
+
+	public void setSensorId(int sensorId) {
+		this.sensorId = sensorId;
+	}
+
+	public long getCount() {
+		return count;
+	}
+
+	public void setCount(long count) {
+		this.count = count;
+	}
+
+	public long getLastUpdate() {
+		return lastUpdate;
+	}
+
+	public void setLastUpdate(long lastUpdate) {
+		this.lastUpdate = lastUpdate;
+	}
+
+	public double getSum() {
+		return sum;
+	}
+
+	public void setSum(double sum) {
+		this.sum = sum;
+	}
+}

--- a/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerSnapshotV1.java
+++ b/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerSnapshotV1.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.flink.training.exercises.custom;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+/**
+ * Serializer configuration snapshot for POJO and format evolution.
+ */
+public final class AggregatedSensorStatisticsSerializerSnapshotV1 implements
+		TypeSerializerSnapshot<AggregatedSensorStatistics> {
+	@Override
+	public int getCurrentVersion() {
+		return 1;
+	}
+
+	@Override
+	public TypeSerializerSchemaCompatibility<AggregatedSensorStatistics> resolveSchemaCompatibility(
+			TypeSerializer<AggregatedSensorStatistics> newSerializer) {
+		if (newSerializer instanceof AggregatedSensorStatisticsSerializerV1) {
+			return TypeSerializerSchemaCompatibility.compatibleAsIs();
+		} else {
+			return TypeSerializerSchemaCompatibility.incompatible();
+		}
+	}
+
+	@Override
+	public TypeSerializer<AggregatedSensorStatistics> restoreSerializer() {
+		return new AggregatedSensorStatisticsSerializerV1();
+	}
+
+	@Override
+	public void writeSnapshot(DataOutputView out) {
+	}
+
+	@Override
+	public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader) {
+	}
+}

--- a/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerSnapshotV2.java
+++ b/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerSnapshotV2.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.flink.training.exercises.custom;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.formats.avro.typeutils.AvroSerializer;
+
+import com.ververica.training.statemigration.avro.AggregatedSensorStatistics;
+
+/**
+ * Serializer configuration snapshot for POJO and format evolution.
+ */
+public final class AggregatedSensorStatisticsSerializerSnapshotV2 implements
+		TypeSerializerSnapshot<AggregatedSensorStatistics> {
+	@Override
+	public int getCurrentVersion() {
+		return 1;
+	}
+
+	@Override
+	public TypeSerializerSchemaCompatibility<AggregatedSensorStatistics> resolveSchemaCompatibility(
+			TypeSerializer<AggregatedSensorStatistics> newSerializer) {
+		if (newSerializer instanceof AggregatedSensorStatisticsSerializerV2) {
+			return TypeSerializerSchemaCompatibility.compatibleAsIs();
+		} else if (newSerializer instanceof AvroSerializer) {
+			return TypeSerializerSchemaCompatibility.compatibleAfterMigration();
+		} else {
+			return TypeSerializerSchemaCompatibility.incompatible();
+		}
+	}
+
+	@Override
+	public TypeSerializer<AggregatedSensorStatistics> restoreSerializer() {
+		return new AggregatedSensorStatisticsSerializerV2();
+	}
+
+	@Override
+	public void writeSnapshot(DataOutputView out) {
+	}
+
+	@Override
+	public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader) {
+	}
+}

--- a/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerV1.java
+++ b/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerV1.java
@@ -1,0 +1,53 @@
+package com.ververica.flink.training.exercises.custom;
+
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import java.io.IOException;
+
+public class AggregatedSensorStatisticsSerializerV1
+		extends AggregatedSensorStatisticsSerializerBase<AggregatedSensorStatistics> {
+
+	private static final long serialVersionUID = 7089080352317847665L;
+
+	@Override
+	public AggregatedSensorStatistics createInstance() {
+		return new AggregatedSensorStatistics();
+	}
+
+	@Override
+	public void serialize(AggregatedSensorStatistics record, DataOutputView target)
+			throws IOException {
+		target.writeInt(record.getSensorId());
+		target.writeLong(record.getCount());
+		target.writeLong(record.getLastUpdate());
+	}
+
+	@Override
+	public AggregatedSensorStatistics deserialize(DataInputView source) throws IOException {
+		int sensorId = source.readInt();
+		long count = source.readLong();
+		long lastUpdate = source.readLong();
+
+		AggregatedSensorStatistics result = new AggregatedSensorStatistics();
+		result.setSensorId(sensorId);
+		result.setCount(count);
+		result.setLastUpdate(lastUpdate);
+		return result;
+	}
+
+	@Override
+	public AggregatedSensorStatistics copy(AggregatedSensorStatistics from) {
+		AggregatedSensorStatistics result = new AggregatedSensorStatistics();
+		result.setSensorId(from.getSensorId());
+		result.setCount(from.getCount());
+		result.setLastUpdate(from.getLastUpdate());
+		return result;
+	}
+
+	@Override
+	public TypeSerializerSnapshot<AggregatedSensorStatistics> snapshotConfiguration() {
+		return new AggregatedSensorStatisticsSerializerSnapshotV1();
+	}
+}

--- a/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerV2.java
+++ b/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerV2.java
@@ -1,0 +1,59 @@
+package com.ververica.flink.training.exercises.custom;
+
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import com.ververica.training.statemigration.avro.AggregatedSensorStatistics;
+
+import java.io.IOException;
+
+public class AggregatedSensorStatisticsSerializerV2
+		extends AggregatedSensorStatisticsSerializerBase<AggregatedSensorStatistics> {
+
+	private static final long serialVersionUID = -6778106052344549131L;
+
+	@Override
+	public AggregatedSensorStatistics createInstance() {
+		return new AggregatedSensorStatistics();
+	}
+
+	@Override
+	public void serialize(AggregatedSensorStatistics record, DataOutputView target)
+			throws IOException {
+		target.writeInt(record.getSensorId());
+		target.writeLong(record.getCount());
+		target.writeDouble(record.getSum());
+		target.writeLong(record.getLastUpdate());
+	}
+
+	@Override
+	public AggregatedSensorStatistics deserialize(DataInputView source) throws IOException {
+		int sensorId = source.readInt();
+		long count = source.readLong();
+		double sum = source.readDouble();
+		long lastUpdate = source.readLong();
+
+		AggregatedSensorStatistics result = new AggregatedSensorStatistics();
+		result.setSensorId(sensorId);
+		result.setCount(count);
+		result.setSum(sum);
+		result.setLastUpdate(lastUpdate);
+		return result;
+	}
+
+	@Override
+	public AggregatedSensorStatistics copy(AggregatedSensorStatistics from) {
+		AggregatedSensorStatistics result = new AggregatedSensorStatistics();
+		result.setSensorId(from.getSensorId());
+		result.setCount(from.getCount());
+		result.setSum(from.getSum());
+		result.setLastUpdate(from.getLastUpdate());
+		return result;
+	}
+
+	@Override
+	public TypeSerializerSnapshot<AggregatedSensorStatistics> snapshotConfiguration() {
+		return new AggregatedSensorStatisticsSerializerSnapshotV2();
+	}
+}

--- a/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/custom/SensorAggregationProcessing.java
+++ b/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/custom/SensorAggregationProcessing.java
@@ -1,0 +1,82 @@
+package com.ververica.flink.training.exercises.custom;
+
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Collector;
+
+import com.ververica.flink.training.common.Measurement;
+import com.ververica.flink.training.exercises.MeasurementAggregationReport;
+import com.ververica.flink.training.exercises.SensorAggregationProcessingBase;
+import com.ververica.flink.training.exercises.StateMigrationJobBase;
+import com.ververica.training.statemigration.avro.AggregatedSensorStatistics;
+
+/**
+ * Process function to report aggregated sensor statistics using a custom serializer for its state.
+ */
+public class SensorAggregationProcessing extends SensorAggregationProcessingBase {
+
+	private static final int REPORTING_INTERVAL = 60_000;
+
+	private static final long serialVersionUID = 4123696380484855346L;
+
+	private transient ValueState<AggregatedSensorStatistics> aggregationState;
+
+	@Override
+	public void processElement(
+			Measurement measurement,
+			Context ctx,
+			Collector<MeasurementAggregationReport> out) throws Exception {
+		if (ctx.timestamp() > ctx.timerService().currentWatermark()) {
+			AggregatedSensorStatistics currentStats = aggregationState.value();
+			if (currentStats == null) {
+				currentStats = new AggregatedSensorStatistics();
+				currentStats.setSensorId(measurement.getSensorId());
+			}
+			currentStats.setCount(currentStats.getCount() + 1);
+			currentStats.setSum(currentStats.getSum() + measurement.getValue());
+
+			// emit once per minute
+			long reportingTime = (ctx.timestamp() / REPORTING_INTERVAL) * REPORTING_INTERVAL;
+			if (reportingTime > ctx.timerService().currentWatermark()) {
+				ctx.timerService().registerEventTimeTimer(reportingTime);
+			}
+
+			aggregationState.update(currentStats);
+		} else {
+			ctx.output(StateMigrationJobBase.LATE_DATA_TAG, measurement);
+		}
+	}
+
+	@Override
+	public void onTimer(
+			long timestamp,
+			OnTimerContext ctx,
+			Collector<MeasurementAggregationReport> out) throws Exception {
+		AggregatedSensorStatistics currentStats = aggregationState.value();
+		currentStats.setLastUpdate(ctx.timestamp());
+
+		MeasurementAggregationReport report = new MeasurementAggregationReport();
+		report.setSensorId(currentStats.getSensorId());
+		report.setCount(currentStats.getCount());
+		report.setAverage(currentStats.getSum() / (double) currentStats.getCount());
+		report.setLatestUpdate(currentStats.getLastUpdate());
+
+		out.collect(report);
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		super.open(parameters);
+
+		final ValueStateDescriptor<AggregatedSensorStatistics> aggregationStateDesc =
+				new ValueStateDescriptor<>("aggregationStats",
+						AggregatedSensorStatistics.class);
+		aggregationState = getRuntimeContext().getState(aggregationStateDesc);
+	}
+
+	@Override
+	public String getStateSerializerName() {
+		return "avro";
+	}
+}

--- a/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/custom/StateMigrationJob.java
+++ b/troubleshooting/state-migration/solution-custom-to-avro/src/main/java/com/ververica/flink/training/exercises/custom/StateMigrationJob.java
@@ -1,0 +1,20 @@
+package com.ververica.flink.training.exercises.custom;
+
+import com.ververica.flink.training.common.DoNotChangeThis;
+import com.ververica.flink.training.exercises.StateMigrationJobBase;
+
+/**
+ * State migration job for custom serializer state migration / schema evolution.
+ */
+@DoNotChangeThis
+public class StateMigrationJob extends StateMigrationJobBase {
+
+	/**
+	 * Creates and starts the state migration streaming job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+	 */
+	public static void main(String[] args) throws Exception {
+		createAndExecuteJob(args, new SensorAggregationProcessing());
+	}
+}

--- a/troubleshooting/state-migration/solution-custom-to-avro/src/main/resources/log4j.properties
+++ b/troubleshooting/state-migration/solution-custom-to-avro/src/main/resources/log4j.properties
@@ -1,0 +1,23 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+log4j.rootLogger=INFO, console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n

--- a/troubleshooting/state-migration/solution/build.gradle
+++ b/troubleshooting/state-migration/solution/build.gradle
@@ -1,0 +1,25 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath "com.commercehub.gradle.plugin:gradle-avro-plugin:0.16.0"
+    }
+}
+apply plugin: "com.commercehub.gradle.plugin.avro"
+
+mainClassName = 'com.ververica.flink.training.exercises.TroubledStreamingJob'
+
+dependencies {
+    flinkShadowJar "com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}"
+    flinkShadowJar "com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}"
+
+    flinkShadowJar "org.apache.flink:flink-avro:${flinkVersion}"
+
+    implementation project(path: ':troubleshooting:state-migration:common')
+    // transitive dependencies for flinkShadowJar need to be defined above
+    // (the alternative of using configuration: 'shadow' does not work there because that adds a dependency on
+    // the jar file, not the sources)
+    flinkShadowJar project(path: ':troubleshooting:common', transitive: false)
+    flinkShadowJar project(path: ':troubleshooting:state-migration:common', transitive: false)
+}

--- a/troubleshooting/state-migration/solution/src/main/avro/AggregatedSensorStatistics.avsc
+++ b/troubleshooting/state-migration/solution/src/main/avro/AggregatedSensorStatistics.avsc
@@ -1,0 +1,25 @@
+{"namespace": "com.ververica.training.statemigration.avro",
+ "type": "record",
+ "name": "AggregatedSensorStatistics",
+ "fields": [
+     {
+     "name": "sensorId",
+     "type": "int"
+     },
+     {
+     "name": "count",
+     "type": "long",
+     "default": 0
+     },
+     {
+     "name": "sum",
+     "type": "double",
+     "default": 0.0
+     },
+     {
+     "name": "lastUpdate",
+     "type": "long",
+     "default": 0
+     }
+ ]
+}

--- a/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/avro/SensorAggregationProcessing.java
+++ b/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/avro/SensorAggregationProcessing.java
@@ -1,0 +1,82 @@
+package com.ververica.flink.training.exercises.avro;
+
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Collector;
+
+import com.ververica.flink.training.common.Measurement;
+import com.ververica.flink.training.exercises.MeasurementAggregationReport;
+import com.ververica.flink.training.exercises.SensorAggregationProcessingBase;
+import com.ververica.flink.training.exercises.StateMigrationJobBase;
+import com.ververica.training.statemigration.avro.AggregatedSensorStatistics;
+
+/**
+ * Process function to report aggregated sensor statistics using Avro-serialized state.
+ */
+public class SensorAggregationProcessing extends SensorAggregationProcessingBase {
+
+	private static final int REPORTING_INTERVAL = 60_000;
+
+	private static final long serialVersionUID = 4123696380484855346L;
+
+	private transient ValueState<AggregatedSensorStatistics> aggregationState;
+
+	@Override
+	public void processElement(
+			Measurement measurement,
+			Context ctx,
+			Collector<MeasurementAggregationReport> out) throws Exception {
+		if (ctx.timestamp() > ctx.timerService().currentWatermark()) {
+			AggregatedSensorStatistics currentStats = aggregationState.value();
+			if (currentStats == null) {
+				currentStats = AggregatedSensorStatistics.newBuilder()
+						.setSensorId(measurement.getSensorId())
+						.build();
+			}
+			currentStats.setCount(currentStats.getCount() + 1);
+			currentStats.setSum(currentStats.getSum() + measurement.getValue());
+
+			// emit once per minute
+			long reportingTime = (ctx.timestamp() / REPORTING_INTERVAL) * REPORTING_INTERVAL;
+			if (reportingTime > ctx.timerService().currentWatermark()) {
+				ctx.timerService().registerEventTimeTimer(reportingTime);
+			}
+
+			aggregationState.update(currentStats);
+		} else {
+			ctx.output(StateMigrationJobBase.LATE_DATA_TAG, measurement);
+		}
+	}
+
+	@Override
+	public void onTimer(
+			long timestamp,
+			OnTimerContext ctx,
+			Collector<MeasurementAggregationReport> out) throws Exception {
+		AggregatedSensorStatistics currentStats = aggregationState.value();
+		currentStats.setLastUpdate(ctx.timestamp());
+
+		MeasurementAggregationReport report = new MeasurementAggregationReport();
+		report.setSensorId(currentStats.getSensorId());
+		report.setCount(currentStats.getCount());
+		report.setAverage(currentStats.getSum() / (double) currentStats.getCount());
+		report.setLatestUpdate(currentStats.getLastUpdate());
+
+		out.collect(report);
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		super.open(parameters);
+
+		final ValueStateDescriptor<AggregatedSensorStatistics> aggregationStateDesc =
+				new ValueStateDescriptor<>("aggregationStats", AggregatedSensorStatistics.class);
+		aggregationState = getRuntimeContext().getState(aggregationStateDesc);
+	}
+
+	@Override
+	public String getStateSerializerName() {
+		return "avro v2";
+	}
+}

--- a/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/avro/StateMigrationJob.java
+++ b/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/avro/StateMigrationJob.java
@@ -1,0 +1,20 @@
+package com.ververica.flink.training.exercises.avro;
+
+import com.ververica.flink.training.common.DoNotChangeThis;
+import com.ververica.flink.training.exercises.StateMigrationJobBase;
+
+/**
+ * State migration job for Avro state migration / schema evolution.
+ */
+@DoNotChangeThis
+public class StateMigrationJob extends StateMigrationJobBase {
+
+    /**
+     * Creates and starts the state migration streaming job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+     */
+	public static void main(String[] args) throws Exception {
+		createAndExecuteJob(args, new SensorAggregationProcessing());
+	}
+}

--- a/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatistics.java
+++ b/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatistics.java
@@ -1,0 +1,46 @@
+package com.ververica.flink.training.exercises.custom;
+
+/**
+ * Sensor statistics state POJO.
+ */
+public class AggregatedSensorStatistics {
+	private int sensorId;
+	private long count;
+	private double sum;
+	private long lastUpdate;
+
+	public AggregatedSensorStatistics() {
+	}
+
+	public int getSensorId() {
+		return sensorId;
+	}
+
+	public void setSensorId(int sensorId) {
+		this.sensorId = sensorId;
+	}
+
+	public long getCount() {
+		return count;
+	}
+
+	public void setCount(long count) {
+		this.count = count;
+	}
+
+	public long getLastUpdate() {
+		return lastUpdate;
+	}
+
+	public void setLastUpdate(long lastUpdate) {
+		this.lastUpdate = lastUpdate;
+	}
+
+	public double getSum() {
+		return sum;
+	}
+
+	public void setSum(double sum) {
+		this.sum = sum;
+	}
+}

--- a/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerSnapshotV1.java
+++ b/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerSnapshotV1.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.flink.training.exercises.custom;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+/**
+ * Serializer configuration snapshot for POJO and format evolution.
+ */
+public final class AggregatedSensorStatisticsSerializerSnapshotV1 implements
+		TypeSerializerSnapshot<AggregatedSensorStatistics> {
+	@Override
+	public int getCurrentVersion() {
+		return 1;
+	}
+
+	@Override
+	public TypeSerializerSchemaCompatibility<AggregatedSensorStatistics> resolveSchemaCompatibility(
+			TypeSerializer<AggregatedSensorStatistics> newSerializer) {
+		if (newSerializer instanceof AggregatedSensorStatisticsSerializerV1) {
+			return TypeSerializerSchemaCompatibility.compatibleAsIs();
+		} else if (newSerializer instanceof AggregatedSensorStatisticsSerializerV2) {
+			return TypeSerializerSchemaCompatibility.compatibleAfterMigration();
+		} else {
+			return TypeSerializerSchemaCompatibility.incompatible();
+		}
+	}
+
+	@Override
+	public TypeSerializer<AggregatedSensorStatistics> restoreSerializer() {
+		return new AggregatedSensorStatisticsSerializerV1();
+	}
+
+	@Override
+	public void writeSnapshot(DataOutputView out) {
+	}
+
+	@Override
+	public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader) {
+	}
+}

--- a/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerSnapshotV2.java
+++ b/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerSnapshotV2.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ververica.flink.training.exercises.custom;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+/**
+ * Serializer configuration snapshot for POJO and format evolution.
+ */
+public final class AggregatedSensorStatisticsSerializerSnapshotV2 implements
+		TypeSerializerSnapshot<AggregatedSensorStatistics> {
+	@Override
+	public int getCurrentVersion() {
+		return 1;
+	}
+
+	@Override
+	public TypeSerializerSchemaCompatibility<AggregatedSensorStatistics> resolveSchemaCompatibility(
+			TypeSerializer<AggregatedSensorStatistics> newSerializer) {
+		if (newSerializer instanceof AggregatedSensorStatisticsSerializerV2) {
+			return TypeSerializerSchemaCompatibility.compatibleAsIs();
+		} else {
+			return TypeSerializerSchemaCompatibility.incompatible();
+		}
+	}
+
+	@Override
+	public TypeSerializer<AggregatedSensorStatistics> restoreSerializer() {
+		return new AggregatedSensorStatisticsSerializerV2();
+	}
+
+	@Override
+	public void writeSnapshot(DataOutputView out) {
+	}
+
+	@Override
+	public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader) {
+	}
+}

--- a/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerV1.java
+++ b/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerV1.java
@@ -1,0 +1,53 @@
+package com.ververica.flink.training.exercises.custom;
+
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import java.io.IOException;
+
+public class AggregatedSensorStatisticsSerializerV1
+		extends AggregatedSensorStatisticsSerializerBase<AggregatedSensorStatistics> {
+
+	private static final long serialVersionUID = 7089080352317847665L;
+
+	@Override
+	public AggregatedSensorStatistics createInstance() {
+		return new AggregatedSensorStatistics();
+	}
+
+	@Override
+	public void serialize(AggregatedSensorStatistics record, DataOutputView target)
+			throws IOException {
+		target.writeInt(record.getSensorId());
+		target.writeLong(record.getCount());
+		target.writeLong(record.getLastUpdate());
+	}
+
+	@Override
+	public AggregatedSensorStatistics deserialize(DataInputView source) throws IOException {
+		int sensorId = source.readInt();
+		long count = source.readLong();
+		long lastUpdate = source.readLong();
+
+		AggregatedSensorStatistics result = new AggregatedSensorStatistics();
+		result.setSensorId(sensorId);
+		result.setCount(count);
+		result.setLastUpdate(lastUpdate);
+		return result;
+	}
+
+	@Override
+	public AggregatedSensorStatistics copy(AggregatedSensorStatistics from) {
+		AggregatedSensorStatistics result = new AggregatedSensorStatistics();
+		result.setSensorId(from.getSensorId());
+		result.setCount(from.getCount());
+		result.setLastUpdate(from.getLastUpdate());
+		return result;
+	}
+
+	@Override
+	public TypeSerializerSnapshot<AggregatedSensorStatistics> snapshotConfiguration() {
+		return new AggregatedSensorStatisticsSerializerSnapshotV1();
+	}
+}

--- a/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerV2.java
+++ b/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/custom/AggregatedSensorStatisticsSerializerV2.java
@@ -1,0 +1,57 @@
+package com.ververica.flink.training.exercises.custom;
+
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import java.io.IOException;
+
+public class AggregatedSensorStatisticsSerializerV2
+		extends AggregatedSensorStatisticsSerializerBase<AggregatedSensorStatistics> {
+
+	private static final long serialVersionUID = -6778106052344549131L;
+
+	@Override
+	public AggregatedSensorStatistics createInstance() {
+		return new AggregatedSensorStatistics();
+	}
+
+	@Override
+	public void serialize(AggregatedSensorStatistics record, DataOutputView target)
+			throws IOException {
+		target.writeInt(record.getSensorId());
+		target.writeLong(record.getCount());
+		target.writeDouble(record.getSum());
+		target.writeLong(record.getLastUpdate());
+	}
+
+	@Override
+	public AggregatedSensorStatistics deserialize(DataInputView source) throws IOException {
+		int sensorId = source.readInt();
+		long count = source.readLong();
+		double sum = source.readDouble();
+		long lastUpdate = source.readLong();
+
+		AggregatedSensorStatistics result = new AggregatedSensorStatistics();
+		result.setSensorId(sensorId);
+		result.setCount(count);
+		result.setSum(sum);
+		result.setLastUpdate(lastUpdate);
+		return result;
+	}
+
+	@Override
+	public AggregatedSensorStatistics copy(AggregatedSensorStatistics from) {
+		AggregatedSensorStatistics result = new AggregatedSensorStatistics();
+		result.setSensorId(from.getSensorId());
+		result.setCount(from.getCount());
+		result.setSum(from.getSum());
+		result.setLastUpdate(from.getLastUpdate());
+		return result;
+	}
+
+	@Override
+	public TypeSerializerSnapshot<AggregatedSensorStatistics> snapshotConfiguration() {
+		return new AggregatedSensorStatisticsSerializerSnapshotV2();
+	}
+}

--- a/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/custom/SensorAggregationProcessing.java
+++ b/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/custom/SensorAggregationProcessing.java
@@ -1,0 +1,81 @@
+package com.ververica.flink.training.exercises.custom;
+
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.Collector;
+
+import com.ververica.flink.training.common.Measurement;
+import com.ververica.flink.training.exercises.MeasurementAggregationReport;
+import com.ververica.flink.training.exercises.SensorAggregationProcessingBase;
+import com.ververica.flink.training.exercises.StateMigrationJobBase;
+
+/**
+ * Process function to report aggregated sensor statistics using a custom serializer for its state.
+ */
+public class SensorAggregationProcessing extends SensorAggregationProcessingBase {
+
+	private static final int REPORTING_INTERVAL = 60_000;
+
+	private static final long serialVersionUID = 4123696380484855346L;
+
+	private transient ValueState<AggregatedSensorStatistics> aggregationState;
+
+	@Override
+	public void processElement(
+			Measurement measurement,
+			Context ctx,
+			Collector<MeasurementAggregationReport> out) throws Exception {
+		if (ctx.timestamp() > ctx.timerService().currentWatermark()) {
+			AggregatedSensorStatistics currentStats = aggregationState.value();
+			if (currentStats == null) {
+				currentStats = new AggregatedSensorStatistics();
+				currentStats.setSensorId(measurement.getSensorId());
+			}
+			currentStats.setCount(currentStats.getCount() + 1);
+			currentStats.setSum(currentStats.getSum() + measurement.getValue());
+
+			// emit once per minute
+			long reportingTime = (ctx.timestamp() / REPORTING_INTERVAL) * REPORTING_INTERVAL;
+			if (reportingTime > ctx.timerService().currentWatermark()) {
+				ctx.timerService().registerEventTimeTimer(reportingTime);
+			}
+
+			aggregationState.update(currentStats);
+		} else {
+			ctx.output(StateMigrationJobBase.LATE_DATA_TAG, measurement);
+		}
+	}
+
+	@Override
+	public void onTimer(
+			long timestamp,
+			OnTimerContext ctx,
+			Collector<MeasurementAggregationReport> out) throws Exception {
+		AggregatedSensorStatistics currentStats = aggregationState.value();
+		currentStats.setLastUpdate(ctx.timestamp());
+
+		MeasurementAggregationReport report = new MeasurementAggregationReport();
+		report.setSensorId(currentStats.getSensorId());
+		report.setCount(currentStats.getCount());
+		report.setAverage(currentStats.getSum() / (double) currentStats.getCount());
+		report.setLatestUpdate(currentStats.getLastUpdate());
+
+		out.collect(report);
+	}
+
+	@Override
+	public void open(Configuration parameters) throws Exception {
+		super.open(parameters);
+
+		final ValueStateDescriptor<AggregatedSensorStatistics> aggregationStateDesc =
+				new ValueStateDescriptor<>("aggregationStats",
+						new AggregatedSensorStatisticsSerializerV2());
+		aggregationState = getRuntimeContext().getState(aggregationStateDesc);
+	}
+
+	@Override
+	public String getStateSerializerName() {
+		return "custom v2";
+	}
+}

--- a/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/custom/StateMigrationJob.java
+++ b/troubleshooting/state-migration/solution/src/main/java/com/ververica/flink/training/exercises/custom/StateMigrationJob.java
@@ -1,0 +1,20 @@
+package com.ververica.flink.training.exercises.custom;
+
+import com.ververica.flink.training.common.DoNotChangeThis;
+import com.ververica.flink.training.exercises.StateMigrationJobBase;
+
+/**
+ * State migration job for custom serializer state migration / schema evolution.
+ */
+@DoNotChangeThis
+public class StateMigrationJob extends StateMigrationJobBase {
+
+	/**
+	 * Creates and starts the state migration streaming job.
+	 *
+	 * @throws Exception if the application is misconfigured or fails during job submission
+	 */
+	public static void main(String[] args) throws Exception {
+		createAndExecuteJob(args, new SensorAggregationProcessing());
+	}
+}

--- a/troubleshooting/state-migration/solution/src/main/resources/log4j.properties
+++ b/troubleshooting/state-migration/solution/src/main/resources/log4j.properties
@@ -1,0 +1,23 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+log4j.rootLogger=INFO, console
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{HH:mm:ss,SSS} %-5p %-60c %x - %m%n


### PR DESCRIPTION
This builds on top of #5 and adds the state migration exercise (and solution) that we last used at Flink Forward San Francisco 2019.

This exercise probably requires some cleanup and I have also not tested whether it is still running. Let's evolve it in the project if needed and for now add it to make it available.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ververica/flink-training/6)
<!-- Reviewable:end -->
