### PR TITLE
update troubleshooting for Flink 1.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,12 +36,12 @@ subprojects {
 
     // artifact properties
     group = 'org.apache.flink'
-    version = '1.11-SNAPSHOT'
+    version = '1.12-SNAPSHOT'
     description = """Flink Training Exercises"""
 
     ext {
         javaVersion = '1.8'
-        flinkVersion = '1.11.2'
+        flinkVersion = '1.12.0'
         scalaBinaryVersion = '2.12'
         jacksonVersion = '2.11.2'
         slf4jVersion = '1.7.15'

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ subprojects {
 
     ext {
         javaVersion = '1.8'
-        flinkVersion = '1.12.0'
+        flinkVersion = '1.12.2'
         scalaBinaryVersion = '2.12'
         jacksonVersion = '2.11.2'
         slf4jVersion = '1.7.15'

--- a/hourly-tips/src/main/java/org/apache/flink/training/exercises/hourlytips/HourlyTipsExercise.java
+++ b/hourly-tips/src/main/java/org/apache/flink/training/exercises/hourlytips/HourlyTipsExercise.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.training.exercises.hourlytips;
 
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.training.exercises.common.datatypes.TaxiFare;
@@ -44,7 +43,6 @@ public class HourlyTipsExercise extends ExerciseBase {
 
 		// set up streaming execution environment
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 		env.setParallelism(ExerciseBase.parallelism);
 
 		// start the data generator

--- a/hourly-tips/src/main/scala/org/apache/flink/training/exercises/hourlytips/scala/HourlyTipsExercise.scala
+++ b/hourly-tips/src/main/scala/org/apache/flink/training/exercises/hourlytips/scala/HourlyTipsExercise.scala
@@ -18,7 +18,6 @@
 
 package org.apache.flink.training.exercises.hourlytips.scala
 
-import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.scala._
 import org.apache.flink.training.exercises.common.sources.TaxiFareGenerator
 import org.apache.flink.training.exercises.common.utils.ExerciseBase._
@@ -37,7 +36,6 @@ object HourlyTipsExercise {
 
     // set up streaming execution environment
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     env.setParallelism(ExerciseBase.parallelism)
 
     // start the data generator

--- a/hourly-tips/src/solution/java/org/apache/flink/training/solutions/hourlytips/HourlyTipsSolution.java
+++ b/hourly-tips/src/solution/java/org/apache/flink/training/solutions/hourlytips/HourlyTipsSolution.java
@@ -19,7 +19,6 @@
 package org.apache.flink.training.solutions.hourlytips;
 
 import org.apache.flink.api.java.tuple.Tuple3;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
@@ -49,7 +48,6 @@ public class HourlyTipsSolution extends ExerciseBase {
 
 		// set up streaming execution environment
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 		env.setParallelism(ExerciseBase.parallelism);
 
 		// start the data generator

--- a/hourly-tips/src/solution/scala/org/apache/flink/training/solutions/hourlytips/scala/HourlyTipsSolution.scala
+++ b/hourly-tips/src/solution/scala/org/apache/flink/training/solutions/hourlytips/scala/HourlyTipsSolution.scala
@@ -18,7 +18,6 @@
 
 package org.apache.flink.training.solutions.hourlytips.scala
 
-import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.scala._
 import org.apache.flink.streaming.api.scala.function.ProcessWindowFunction
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows
@@ -43,7 +42,6 @@ object HourlyTipsSolution {
 
     // set up streaming execution environment
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     env.setParallelism(ExerciseBase.parallelism)
 
     // start the data generator

--- a/long-ride-alerts/src/main/java/org/apache/flink/training/exercises/longrides/LongRidesExercise.java
+++ b/long-ride-alerts/src/main/java/org/apache/flink/training/exercises/longrides/LongRidesExercise.java
@@ -19,7 +19,6 @@
 package org.apache.flink.training.exercises.longrides;
 
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.TimerService;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -48,7 +47,6 @@ public class LongRidesExercise extends ExerciseBase {
 
 		// set up streaming execution environment
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 		env.setParallelism(ExerciseBase.parallelism);
 
 		// start the data generator

--- a/long-ride-alerts/src/main/scala/org/apache/flink/training/exercises/longrides/scala/LongRidesExercise.scala
+++ b/long-ride-alerts/src/main/scala/org/apache/flink/training/exercises/longrides/scala/LongRidesExercise.scala
@@ -19,7 +19,6 @@
 package org.apache.flink.training.exercises.longrides.scala
 
 import org.apache.flink.configuration.Configuration
-import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction
 import org.apache.flink.streaming.api.scala.{StreamExecutionEnvironment, _}
 import org.apache.flink.training.exercises.common.datatypes.TaxiRide
@@ -41,7 +40,6 @@ object LongRidesExercise {
 
     // set up the execution environment
     val env = StreamExecutionEnvironment.getExecutionEnvironment
-    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     env.setParallelism(ExerciseBase.parallelism)
 
     val rides = env.addSource(rideSourceOrTest(new TaxiRideGenerator()))

--- a/long-ride-alerts/src/solution/java/org/apache/flink/training/solutions/longrides/LongRidesSolution.java
+++ b/long-ride-alerts/src/solution/java/org/apache/flink/training/solutions/longrides/LongRidesSolution.java
@@ -21,7 +21,6 @@ package org.apache.flink.training.solutions.longrides;
 import org.apache.flink.api.common.state.ValueState;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
@@ -48,7 +47,6 @@ public class LongRidesSolution extends ExerciseBase {
 
 		// set up streaming execution environment
 		StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 		env.setParallelism(ExerciseBase.parallelism);
 
 		// start the data generator

--- a/long-ride-alerts/src/solution/scala/org/apache/flink/training/solutions/longrides/scala/LongRidesSolution.scala
+++ b/long-ride-alerts/src/solution/scala/org/apache/flink/training/solutions/longrides/scala/LongRidesSolution.scala
@@ -20,7 +20,6 @@ package org.apache.flink.training.solutions.longrides.scala
 
 import scala.concurrent.duration._
 import org.apache.flink.api.common.state.{ValueState, ValueStateDescriptor}
-import org.apache.flink.streaming.api.TimeCharacteristic
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction
 import org.apache.flink.streaming.api.scala.{StreamExecutionEnvironment, _}
 import org.apache.flink.training.exercises.common.datatypes.TaxiRide
@@ -43,7 +42,6 @@ object LongRidesSolution {
     // set up the execution environment
     val env = StreamExecutionEnvironment.getExecutionEnvironment
     // operate in Event-time
-    env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime)
     env.setParallelism(ExerciseBase.parallelism)
 
     val rides = env.addSource(rideSourceOrTest(new TaxiRideGenerator()))

--- a/troubleshooting/checkpointing/src/main/java/com/ververica/flink/training/exercises/CheckpointingJob.java
+++ b/troubleshooting/checkpointing/src/main/java/com/ververica/flink/training/exercises/CheckpointingJob.java
@@ -8,7 +8,6 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
@@ -49,8 +48,7 @@ public class CheckpointingJob {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(100);
 		env.setBufferTimeout(10);
 

--- a/troubleshooting/checkpointing/src/solution/java/com/ververica/flink/training/solutions/CheckpointingJobSolution2.java
+++ b/troubleshooting/checkpointing/src/solution/java/com/ververica/flink/training/solutions/CheckpointingJobSolution2.java
@@ -7,7 +7,6 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
@@ -49,8 +48,7 @@ public class CheckpointingJobSolution2 {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(100);
 		env.setBufferTimeout(10);
 

--- a/troubleshooting/external-enrichment/src/main/java/com/ververica/flink/training/exercises/ExternalEnrichmentJob.java
+++ b/troubleshooting/external-enrichment/src/main/java/com/ververica/flink/training/exercises/ExternalEnrichmentJob.java
@@ -6,7 +6,6 @@ import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
@@ -44,8 +43,7 @@ public class ExternalEnrichmentJob {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(100);
 		env.setBufferTimeout(10);
 

--- a/troubleshooting/external-enrichment/src/solution/java/com/ververica/flink/training/solutions/ExternalEnrichmentJobSolution.java
+++ b/troubleshooting/external-enrichment/src/solution/java/com/ververica/flink/training/solutions/ExternalEnrichmentJobSolution.java
@@ -5,7 +5,6 @@ import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.AsyncDataStream;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -49,8 +48,7 @@ public class ExternalEnrichmentJobSolution {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(100);
 		env.setBufferTimeout(10);
 

--- a/troubleshooting/introduction/src/main/java/com/ververica/flink/training/exercises/TroubledStreamingJob.java
+++ b/troubleshooting/introduction/src/main/java/com/ververica/flink/training/exercises/TroubledStreamingJob.java
@@ -4,13 +4,13 @@ import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.timestamps.BoundedOutOfOrdernessTimestampExtractor;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.util.Collector;
@@ -44,8 +44,7 @@ public class TroubledStreamingJob {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(2000);
 
 		//Checkpointing Configuration
@@ -69,7 +68,7 @@ public class TroubledStreamingJob {
 
 		SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
 				.keyBy(jsonNode -> jsonNode.get("location").asText())
-				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.window(TumblingEventTimeWindows.of(Time.seconds(1)))
 				.sideOutputLateData(lateDataTag)
 				.process(new MeasurementWindowAggregatingFunction())
 				.name("WindowedAggregationPerLocation")

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution1.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution1.java
@@ -5,13 +5,13 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.timestamps.BoundedOutOfOrdernessTimestampExtractor;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.util.Collector;
@@ -46,8 +46,7 @@ public class TroubledStreamingJobSolution1 {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(2000);
 
 		//Checkpointing Configuration
@@ -71,7 +70,7 @@ public class TroubledStreamingJobSolution1 {
 
 		SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
 				.keyBy(jsonNode -> jsonNode.get("location").asText())
-				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.window(TumblingEventTimeWindows.of(Time.seconds(1)))
 				.sideOutputLateData(lateDataTag)
 				.process(new MeasurementWindowAggregatingFunction())
 				.name("WindowedAggregationPerLocation")

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution2.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution2.java
@@ -1,5 +1,6 @@
 package com.ververica.flink.training.solutions;
 
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
@@ -8,10 +9,8 @@ import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
-import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
@@ -26,7 +25,7 @@ import com.ververica.flink.training.common.SourceUtils;
 import com.ververica.flink.training.common.WindowedMeasurements;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
 import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
@@ -59,8 +58,11 @@ public class TroubledStreamingJobSolution2 {
 				.name("FakeKafkaSource")
 				.uid("FakeKafkaSource")
 				.assignTimestampsAndWatermarks(
-						new MeasurementTSExtractor(Time.of(250, TimeUnit.MILLISECONDS),
-								Time.of(1, TimeUnit.SECONDS)))
+						WatermarkStrategy
+								.<FakeKafkaRecord>forBoundedOutOfOrderness(Duration.ofMillis(250))
+								.withTimestampAssigner(
+										(element, timestamp) -> element.getTimestamp())
+								.withIdleness(Duration.ofSeconds(1)))
 				.name("Watermarks")
 				.uid("Watermarks")
 				.flatMap(new MeasurementDeserializer())
@@ -131,69 +133,6 @@ public class TroubledStreamingJobSolution2 {
 
 		private JsonNode deserialize(final byte[] bytes) throws IOException {
 			return ObjectMapperSingleton.getInstance().readValue(bytes, JsonNode.class);
-		}
-	}
-
-	public static class MeasurementTSExtractor implements
-			AssignerWithPeriodicWatermarks<FakeKafkaRecord> {
-		private static final long serialVersionUID = 2L;
-
-		private long currentMaxTimestamp;
-		private long lastEmittedWatermark = Long.MIN_VALUE;
-		private long lastRecordProcessingTime;
-
-		private final long maxOutOfOrderness;
-		private final long idleTimeout;
-
-		MeasurementTSExtractor(Time maxOutOfOrderness, Time idleTimeout) {
-			if (maxOutOfOrderness.toMilliseconds() < 0) {
-				throw new RuntimeException("Tried to set the maximum allowed " +
-						"lateness to " + maxOutOfOrderness +
-						". This parameter cannot be negative.");
-			}
-
-			if (idleTimeout.toMilliseconds() < 0) {
-				throw new RuntimeException("Tried to set the idle Timeout" + idleTimeout +
-						". This parameter cannot be negative.");
-			}
-
-			this.maxOutOfOrderness = maxOutOfOrderness.toMilliseconds();
-			this.idleTimeout = idleTimeout.toMilliseconds();
-			this.currentMaxTimestamp = Long.MIN_VALUE;
-		}
-
-        /**
-         * Gets the configured out of orderness (in ms).
-         */
-		public long getMaxOutOfOrdernessInMillis() {
-			return maxOutOfOrderness;
-		}
-
-		@Override
-		public final Watermark getCurrentWatermark() {
-
-			// if last record was processed more than the idleTimeout in the past, consider this
-			// source idle and set timestamp to current processing time
-			long currentProcessingTime = System.currentTimeMillis();
-			if (lastRecordProcessingTime < currentProcessingTime - idleTimeout) {
-				this.currentMaxTimestamp = currentProcessingTime;
-			}
-
-			long potentialWM = this.currentMaxTimestamp - maxOutOfOrderness;
-			if (potentialWM >= lastEmittedWatermark) {
-				lastEmittedWatermark = potentialWM;
-			}
-			return new Watermark(lastEmittedWatermark);
-		}
-
-		@Override
-		public final long extractTimestamp(FakeKafkaRecord element, long previousElementTimestamp) {
-			lastRecordProcessingTime = System.currentTimeMillis();
-			long timestamp = element.getTimestamp();
-			if (timestamp > currentMaxTimestamp) {
-				currentMaxTimestamp = timestamp;
-			}
-			return timestamp;
 		}
 	}
 

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution2.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution2.java
@@ -5,7 +5,6 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -13,6 +12,7 @@ import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.util.Collector;
@@ -47,8 +47,7 @@ public class TroubledStreamingJobSolution2 {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(2000);
 
 		//Checkpointing Configuration
@@ -74,7 +73,7 @@ public class TroubledStreamingJobSolution2 {
 
 		SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
 				.keyBy(jsonNode -> jsonNode.get("location").asText())
-				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.window(TumblingEventTimeWindows.of(Time.seconds(1)))
 				.sideOutputLateData(lateDataTag)
 				.process(new MeasurementWindowAggregatingFunction())
 				.name("WindowedAggregationPerLocation")

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution31.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution31.java
@@ -1,5 +1,6 @@
 package com.ververica.flink.training.solutions;
 
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
@@ -8,10 +9,8 @@ import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
-import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
@@ -26,7 +25,7 @@ import com.ververica.flink.training.common.SourceUtils;
 import com.ververica.flink.training.common.WindowedMeasurements;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
 import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
@@ -59,8 +58,11 @@ public class TroubledStreamingJobSolution31 {
 				.name("FakeKafkaSource")
 				.uid("FakeKafkaSource")
 				.assignTimestampsAndWatermarks(
-						new MeasurementTSExtractor(Time.of(250, TimeUnit.MILLISECONDS),
-								Time.of(1, TimeUnit.SECONDS)))
+						WatermarkStrategy
+								.<FakeKafkaRecord>forBoundedOutOfOrderness(Duration.ofMillis(250))
+								.withTimestampAssigner(
+										(element, timestamp) -> element.getTimestamp())
+								.withIdleness(Duration.ofSeconds(1)))
 				.name("Watermarks")
 				.uid("Watermarks")
 				.flatMap(new MeasurementDeserializer())
@@ -131,69 +133,6 @@ public class TroubledStreamingJobSolution31 {
 
 		private JsonNode deserialize(final byte[] bytes) throws IOException {
 			return ObjectMapperSingleton.getInstance().readValue(bytes, JsonNode.class);
-		}
-	}
-
-	public static class MeasurementTSExtractor implements
-			AssignerWithPeriodicWatermarks<FakeKafkaRecord> {
-		private static final long serialVersionUID = 2L;
-
-		private long currentMaxTimestamp;
-		private long lastEmittedWatermark = Long.MIN_VALUE;
-		private long lastRecordProcessingTime;
-
-		private final long maxOutOfOrderness;
-		private final long idleTimeout;
-
-		MeasurementTSExtractor(Time maxOutOfOrderness, Time idleTimeout) {
-			if (maxOutOfOrderness.toMilliseconds() < 0) {
-				throw new RuntimeException("Tried to set the maximum allowed " +
-						"lateness to " + maxOutOfOrderness +
-						". This parameter cannot be negative.");
-			}
-
-			if (idleTimeout.toMilliseconds() < 0) {
-				throw new RuntimeException("Tried to set the idle Timeout" + idleTimeout +
-						". This parameter cannot be negative.");
-			}
-
-			this.maxOutOfOrderness = maxOutOfOrderness.toMilliseconds();
-			this.idleTimeout = idleTimeout.toMilliseconds();
-			this.currentMaxTimestamp = Long.MIN_VALUE;
-		}
-
-        /**
-         * Gets the configured out of orderness (in ms).
-         */
-		public long getMaxOutOfOrdernessInMillis() {
-			return maxOutOfOrderness;
-		}
-
-		@Override
-		public final Watermark getCurrentWatermark() {
-
-			// if last record was processed more than the idleTimeout in the past, consider this
-			// source idle and set timestamp to current processing time
-			long currentProcessingTime = System.currentTimeMillis();
-			if (lastRecordProcessingTime < currentProcessingTime - idleTimeout) {
-				this.currentMaxTimestamp = currentProcessingTime;
-			}
-
-			long potentialWM = this.currentMaxTimestamp - maxOutOfOrderness;
-			if (potentialWM >= lastEmittedWatermark) {
-				lastEmittedWatermark = potentialWM;
-			}
-			return new Watermark(lastEmittedWatermark);
-		}
-
-		@Override
-		public final long extractTimestamp(FakeKafkaRecord element, long previousElementTimestamp) {
-			lastRecordProcessingTime = System.currentTimeMillis();
-			long timestamp = element.getTimestamp();
-			if (timestamp > currentMaxTimestamp) {
-				currentMaxTimestamp = timestamp;
-			}
-			return timestamp;
 		}
 	}
 

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution31.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution31.java
@@ -5,7 +5,6 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -13,6 +12,7 @@ import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.util.Collector;
@@ -47,8 +47,7 @@ public class TroubledStreamingJobSolution31 {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(100);
 
 		//Checkpointing Configuration
@@ -74,7 +73,7 @@ public class TroubledStreamingJobSolution31 {
 
 		SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
 				.keyBy(jsonNode -> jsonNode.get("location").asText())
-				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.window(TumblingEventTimeWindows.of(Time.seconds(1)))
 				.sideOutputLateData(lateDataTag)
 				.process(new MeasurementWindowAggregatingFunction())
 				.name("WindowedAggregationPerLocation")

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution32.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution32.java
@@ -6,7 +6,6 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -14,6 +13,7 @@ import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.util.Collector;
@@ -48,8 +48,7 @@ public class TroubledStreamingJobSolution32 {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(100);
 
 		//Checkpointing Configuration
@@ -75,7 +74,7 @@ public class TroubledStreamingJobSolution32 {
 
 		SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
 				.keyBy(jsonNode -> jsonNode.get("location").asText())
-				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.window(TumblingEventTimeWindows.of(Time.seconds(1)))
 				.sideOutputLateData(lateDataTag)
 				.aggregate(new MeasurementWindowAggregatingFunction(),
 						new MeasurementWindowProcessFunction())

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution32.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution32.java
@@ -1,5 +1,6 @@
 package com.ververica.flink.training.solutions;
 
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.java.utils.ParameterTool;
@@ -9,10 +10,8 @@ import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
-import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
@@ -27,7 +26,7 @@ import com.ververica.flink.training.common.SourceUtils;
 import com.ververica.flink.training.common.WindowedMeasurements;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
 import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
@@ -60,8 +59,11 @@ public class TroubledStreamingJobSolution32 {
 				.name("FakeKafkaSource")
 				.uid("FakeKafkaSource")
 				.assignTimestampsAndWatermarks(
-						new MeasurementTSExtractor(Time.of(250, TimeUnit.MILLISECONDS),
-								Time.of(1, TimeUnit.SECONDS)))
+						WatermarkStrategy
+								.<FakeKafkaRecord>forBoundedOutOfOrderness(Duration.ofMillis(250))
+								.withTimestampAssigner(
+										(element, timestamp) -> element.getTimestamp())
+								.withIdleness(Duration.ofSeconds(1)))
 				.name("Watermarks")
 				.uid("Watermarks")
 				.flatMap(new MeasurementDeserializer())
@@ -133,69 +135,6 @@ public class TroubledStreamingJobSolution32 {
 
 		private JsonNode deserialize(final byte[] bytes) throws IOException {
 			return ObjectMapperSingleton.getInstance().readValue(bytes, JsonNode.class);
-		}
-	}
-
-	public static class MeasurementTSExtractor implements
-			AssignerWithPeriodicWatermarks<FakeKafkaRecord> {
-		private static final long serialVersionUID = 2L;
-
-		private long currentMaxTimestamp;
-		private long lastEmittedWatermark = Long.MIN_VALUE;
-		private long lastRecordProcessingTime;
-
-		private final long maxOutOfOrderness;
-		private final long idleTimeout;
-
-		MeasurementTSExtractor(Time maxOutOfOrderness, Time idleTimeout) {
-			if (maxOutOfOrderness.toMilliseconds() < 0) {
-				throw new RuntimeException("Tried to set the maximum allowed " +
-						"lateness to " + maxOutOfOrderness +
-						". This parameter cannot be negative.");
-			}
-
-			if (idleTimeout.toMilliseconds() < 0) {
-				throw new RuntimeException("Tried to set the idle Timeout" + idleTimeout +
-						". This parameter cannot be negative.");
-			}
-
-			this.maxOutOfOrderness = maxOutOfOrderness.toMilliseconds();
-			this.idleTimeout = idleTimeout.toMilliseconds();
-			this.currentMaxTimestamp = Long.MIN_VALUE;
-		}
-
-        /**
-         * Gets the configured out of orderness (in ms).
-         */
-		public long getMaxOutOfOrdernessInMillis() {
-			return maxOutOfOrderness;
-		}
-
-		@Override
-		public final Watermark getCurrentWatermark() {
-
-			// if last record was processed more than the idleTimeout in the past, consider this
-			// source idle and set timestamp to current processing time
-			long currentProcessingTime = System.currentTimeMillis();
-			if (lastRecordProcessingTime < currentProcessingTime - idleTimeout) {
-				this.currentMaxTimestamp = currentProcessingTime;
-			}
-
-			long potentialWM = this.currentMaxTimestamp - maxOutOfOrderness;
-			if (potentialWM >= lastEmittedWatermark) {
-				lastEmittedWatermark = potentialWM;
-			}
-			return new Watermark(lastEmittedWatermark);
-		}
-
-		@Override
-		public final long extractTimestamp(FakeKafkaRecord element, long previousElementTimestamp) {
-			lastRecordProcessingTime = System.currentTimeMillis();
-			long timestamp = element.getTimestamp();
-			if (timestamp > currentMaxTimestamp) {
-				currentMaxTimestamp = timestamp;
-			}
-			return timestamp;
 		}
 	}
 

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution33.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution33.java
@@ -6,7 +6,6 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -14,6 +13,7 @@ import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.util.Collector;
@@ -48,8 +48,7 @@ public class TroubledStreamingJobSolution33 {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(100);
 		env.setBufferTimeout(10);
 
@@ -76,7 +75,7 @@ public class TroubledStreamingJobSolution33 {
 
 		SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
 				.keyBy(jsonNode -> jsonNode.get("location").asText())
-				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.window(TumblingEventTimeWindows.of(Time.seconds(1)))
 				.sideOutputLateData(lateDataTag)
 				.aggregate(new MeasurementWindowAggregatingFunction(),
 						new MeasurementWindowProcessFunction())

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution33.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution33.java
@@ -1,5 +1,6 @@
 package com.ververica.flink.training.solutions;
 
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.java.utils.ParameterTool;
@@ -9,10 +10,8 @@ import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
-import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
@@ -27,7 +26,7 @@ import com.ververica.flink.training.common.SourceUtils;
 import com.ververica.flink.training.common.WindowedMeasurements;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
 import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
@@ -61,8 +60,11 @@ public class TroubledStreamingJobSolution33 {
 				.name("FakeKafkaSource")
 				.uid("FakeKafkaSource")
 				.assignTimestampsAndWatermarks(
-						new MeasurementTSExtractor(Time.of(250, TimeUnit.MILLISECONDS),
-								Time.of(1, TimeUnit.SECONDS)))
+						WatermarkStrategy
+								.<FakeKafkaRecord>forBoundedOutOfOrderness(Duration.ofMillis(250))
+								.withTimestampAssigner(
+										(element, timestamp) -> element.getTimestamp())
+								.withIdleness(Duration.ofSeconds(1)))
 				.name("Watermarks")
 				.uid("Watermarks")
 				.flatMap(new MeasurementDeserializer())
@@ -134,69 +136,6 @@ public class TroubledStreamingJobSolution33 {
 
 		private JsonNode deserialize(final byte[] bytes) throws IOException {
 			return ObjectMapperSingleton.getInstance().readValue(bytes, JsonNode.class);
-		}
-	}
-
-	public static class MeasurementTSExtractor implements
-			AssignerWithPeriodicWatermarks<FakeKafkaRecord> {
-		private static final long serialVersionUID = 2L;
-
-		private long currentMaxTimestamp;
-		private long lastEmittedWatermark = Long.MIN_VALUE;
-		private long lastRecordProcessingTime;
-
-		private final long maxOutOfOrderness;
-		private final long idleTimeout;
-
-		MeasurementTSExtractor(Time maxOutOfOrderness, Time idleTimeout) {
-			if (maxOutOfOrderness.toMilliseconds() < 0) {
-				throw new RuntimeException("Tried to set the maximum allowed " +
-						"lateness to " + maxOutOfOrderness +
-						". This parameter cannot be negative.");
-			}
-
-			if (idleTimeout.toMilliseconds() < 0) {
-				throw new RuntimeException("Tried to set the idle Timeout" + idleTimeout +
-						". This parameter cannot be negative.");
-			}
-
-			this.maxOutOfOrderness = maxOutOfOrderness.toMilliseconds();
-			this.idleTimeout = idleTimeout.toMilliseconds();
-			this.currentMaxTimestamp = Long.MIN_VALUE;
-		}
-
-		/**
-		 * Gets the configured out of orderness (in ms).
-		 */
-		public long getMaxOutOfOrdernessInMillis() {
-			return maxOutOfOrderness;
-		}
-
-		@Override
-		public final Watermark getCurrentWatermark() {
-
-			// if last record was processed more than the idleTimeout in the past, consider this
-			// source idle and set timestamp to current processing time
-			long currentProcessingTime = System.currentTimeMillis();
-			if (lastRecordProcessingTime < currentProcessingTime - idleTimeout) {
-				this.currentMaxTimestamp = currentProcessingTime;
-			}
-
-			long potentialWM = this.currentMaxTimestamp - maxOutOfOrderness;
-			if (potentialWM >= lastEmittedWatermark) {
-				lastEmittedWatermark = potentialWM;
-			}
-			return new Watermark(lastEmittedWatermark);
-		}
-
-		@Override
-		public final long extractTimestamp(FakeKafkaRecord element, long previousElementTimestamp) {
-			lastRecordProcessingTime = System.currentTimeMillis();
-			long timestamp = element.getTimestamp();
-			if (timestamp > currentMaxTimestamp) {
-				currentMaxTimestamp = timestamp;
-			}
-			return timestamp;
 		}
 	}
 

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution41.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution41.java
@@ -1,5 +1,6 @@
 package com.ververica.flink.training.solutions;
 
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.java.utils.ParameterTool;
@@ -9,10 +10,8 @@ import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
-import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
@@ -27,7 +26,7 @@ import com.ververica.flink.training.common.SourceUtils;
 import com.ververica.flink.training.common.WindowedMeasurements;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
 import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
@@ -61,8 +60,11 @@ public class TroubledStreamingJobSolution41 {
 				.name("FakeKafkaSource")
 				.uid("FakeKafkaSource")
 				.assignTimestampsAndWatermarks(
-						new MeasurementTSExtractor(Time.of(250, TimeUnit.MILLISECONDS),
-								Time.of(1, TimeUnit.SECONDS)))
+						WatermarkStrategy
+								.<FakeKafkaRecord>forBoundedOutOfOrderness(Duration.ofMillis(250))
+								.withTimestampAssigner(
+										(element, timestamp) -> element.getTimestamp())
+								.withIdleness(Duration.ofSeconds(1)))
 				.name("Watermarks")
 				.uid("Watermarks")
 				.flatMap(new MeasurementDeserializer())
@@ -134,69 +136,6 @@ public class TroubledStreamingJobSolution41 {
 
 		private Measurement deserialize(final byte[] bytes) throws IOException {
 			return ObjectMapperSingleton.getInstance().readValue(bytes, Measurement.class);
-		}
-	}
-
-	public static class MeasurementTSExtractor implements
-			AssignerWithPeriodicWatermarks<FakeKafkaRecord> {
-		private static final long serialVersionUID = 2L;
-
-		private long currentMaxTimestamp;
-		private long lastEmittedWatermark = Long.MIN_VALUE;
-		private long lastRecordProcessingTime;
-
-		private final long maxOutOfOrderness;
-		private final long idleTimeout;
-
-		MeasurementTSExtractor(Time maxOutOfOrderness, Time idleTimeout) {
-			if (maxOutOfOrderness.toMilliseconds() < 0) {
-				throw new RuntimeException("Tried to set the maximum allowed " +
-						"lateness to " + maxOutOfOrderness +
-						". This parameter cannot be negative.");
-			}
-
-			if (idleTimeout.toMilliseconds() < 0) {
-				throw new RuntimeException("Tried to set the idle Timeout" + idleTimeout +
-						". This parameter cannot be negative.");
-			}
-
-			this.maxOutOfOrderness = maxOutOfOrderness.toMilliseconds();
-			this.idleTimeout = idleTimeout.toMilliseconds();
-			this.currentMaxTimestamp = Long.MIN_VALUE;
-		}
-
-		/**
-		 * Gets the configured out of orderness (in ms).
-		 */
-		public long getMaxOutOfOrdernessInMillis() {
-			return maxOutOfOrderness;
-		}
-
-		@Override
-		public final Watermark getCurrentWatermark() {
-
-			// if last record was processed more than the idleTimeout in the past, consider this
-			// source idle and set timestamp to current processing time
-			long currentProcessingTime = System.currentTimeMillis();
-			if (lastRecordProcessingTime < currentProcessingTime - idleTimeout) {
-				this.currentMaxTimestamp = currentProcessingTime;
-			}
-
-			long potentialWM = this.currentMaxTimestamp - maxOutOfOrderness;
-			if (potentialWM >= lastEmittedWatermark) {
-				lastEmittedWatermark = potentialWM;
-			}
-			return new Watermark(lastEmittedWatermark);
-		}
-
-		@Override
-		public final long extractTimestamp(FakeKafkaRecord element, long previousElementTimestamp) {
-			lastRecordProcessingTime = System.currentTimeMillis();
-			long timestamp = element.getTimestamp();
-			if (timestamp > currentMaxTimestamp) {
-				currentMaxTimestamp = timestamp;
-			}
-			return timestamp;
 		}
 	}
 

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution41.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution41.java
@@ -6,7 +6,6 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -14,6 +13,7 @@ import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.util.Collector;
@@ -48,8 +48,7 @@ public class TroubledStreamingJobSolution41 {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(100);
 		env.setBufferTimeout(10);
 
@@ -76,7 +75,7 @@ public class TroubledStreamingJobSolution41 {
 
 		SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
 				.keyBy(Measurement::getLocation)
-				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.window(TumblingEventTimeWindows.of(Time.seconds(1)))
 				.sideOutputLateData(lateDataTag)
 				.aggregate(new MeasurementWindowAggregatingFunction(),
 						new MeasurementWindowProcessFunction())

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution42.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution42.java
@@ -6,7 +6,6 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -14,6 +13,7 @@ import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.util.Collector;
@@ -48,8 +48,7 @@ public class TroubledStreamingJobSolution42 {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(100);
 		env.setBufferTimeout(10);
 
@@ -76,7 +75,7 @@ public class TroubledStreamingJobSolution42 {
 
 		SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
 				.keyBy(Measurement::getLocation)
-				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.window(TumblingEventTimeWindows.of(Time.seconds(1)))
 				.sideOutputLateData(lateDataTag)
 				.aggregate(new MeasurementWindowAggregatingFunction(),
 						new MeasurementWindowProcessFunction())

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution42.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution42.java
@@ -1,5 +1,6 @@
 package com.ververica.flink.training.solutions;
 
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.java.utils.ParameterTool;
@@ -9,10 +10,8 @@ import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
-import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
@@ -27,7 +26,7 @@ import com.ververica.flink.training.common.SourceUtils;
 import com.ververica.flink.training.common.WindowedMeasurements;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
 import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
@@ -61,8 +60,11 @@ public class TroubledStreamingJobSolution42 {
 				.name("FakeKafkaSource")
 				.uid("FakeKafkaSource")
 				.assignTimestampsAndWatermarks(
-						new MeasurementTSExtractor(Time.of(250, TimeUnit.MILLISECONDS),
-								Time.of(1, TimeUnit.SECONDS)))
+						WatermarkStrategy
+								.<FakeKafkaRecord>forBoundedOutOfOrderness(Duration.ofMillis(250))
+								.withTimestampAssigner(
+										(element, timestamp) -> element.getTimestamp())
+								.withIdleness(Duration.ofSeconds(1)))
 				.name("Watermarks")
 				.uid("Watermarks")
 				.flatMap(new MeasurementDeserializer())
@@ -136,69 +138,6 @@ public class TroubledStreamingJobSolution42 {
 
 		private Measurement deserialize(final byte[] bytes) throws IOException {
 			return instance.readValue(bytes, Measurement.class);
-		}
-	}
-
-	public static class MeasurementTSExtractor implements
-			AssignerWithPeriodicWatermarks<FakeKafkaRecord> {
-		private static final long serialVersionUID = 2L;
-
-		private long currentMaxTimestamp;
-		private long lastEmittedWatermark = Long.MIN_VALUE;
-		private long lastRecordProcessingTime;
-
-		private final long maxOutOfOrderness;
-		private final long idleTimeout;
-
-		MeasurementTSExtractor(Time maxOutOfOrderness, Time idleTimeout) {
-			if (maxOutOfOrderness.toMilliseconds() < 0) {
-				throw new RuntimeException("Tried to set the maximum allowed " +
-						"lateness to " + maxOutOfOrderness +
-						". This parameter cannot be negative.");
-			}
-
-			if (idleTimeout.toMilliseconds() < 0) {
-				throw new RuntimeException("Tried to set the idle Timeout" + idleTimeout +
-						". This parameter cannot be negative.");
-			}
-
-			this.maxOutOfOrderness = maxOutOfOrderness.toMilliseconds();
-			this.idleTimeout = idleTimeout.toMilliseconds();
-			this.currentMaxTimestamp = Long.MIN_VALUE;
-		}
-
-		/**
-		 * Gets the configured out of orderness (in ms).
-		 */
-		public long getMaxOutOfOrdernessInMillis() {
-			return maxOutOfOrderness;
-		}
-
-		@Override
-		public final Watermark getCurrentWatermark() {
-
-			// if last record was processed more than the idleTimeout in the past, consider this
-			// source idle and set timestamp to current processing time
-			long currentProcessingTime = System.currentTimeMillis();
-			if (lastRecordProcessingTime < currentProcessingTime - idleTimeout) {
-				this.currentMaxTimestamp = currentProcessingTime;
-			}
-
-			long potentialWM = this.currentMaxTimestamp - maxOutOfOrderness;
-			if (potentialWM >= lastEmittedWatermark) {
-				lastEmittedWatermark = potentialWM;
-			}
-			return new Watermark(lastEmittedWatermark);
-		}
-
-		@Override
-		public final long extractTimestamp(FakeKafkaRecord element, long previousElementTimestamp) {
-			lastRecordProcessingTime = System.currentTimeMillis();
-			long timestamp = element.getTimestamp();
-			if (timestamp > currentMaxTimestamp) {
-				currentMaxTimestamp = timestamp;
-			}
-			return timestamp;
 		}
 	}
 

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution43.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution43.java
@@ -1,5 +1,6 @@
 package com.ververica.flink.training.solutions;
 
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.java.utils.ParameterTool;
@@ -9,10 +10,8 @@ import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
-import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
@@ -26,7 +25,7 @@ import com.ververica.flink.training.common.SourceUtils;
 import com.ververica.flink.training.common.WindowedMeasurements;
 
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
 import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
@@ -60,8 +59,11 @@ public class TroubledStreamingJobSolution43 {
 				.name("FakeKafkaSource")
 				.uid("FakeKafkaSource")
 				.assignTimestampsAndWatermarks(
-						new MeasurementTSExtractor(Time.of(250, TimeUnit.MILLISECONDS),
-								Time.of(1, TimeUnit.SECONDS)))
+						WatermarkStrategy
+								.<FakeKafkaRecord>forBoundedOutOfOrderness(Duration.ofMillis(250))
+								.withTimestampAssigner(
+										(element, timestamp) -> element.getTimestamp())
+								.withIdleness(Duration.ofSeconds(1)))
 				.name("Watermarks")
 				.uid("Watermarks")
 				.flatMap(new MeasurementDeserializer())
@@ -137,69 +139,6 @@ public class TroubledStreamingJobSolution43 {
 
 		private SimpleMeasurement deserialize(final byte[] bytes) throws IOException {
 			return instance.readValue(bytes, SimpleMeasurement.class);
-		}
-	}
-
-	public static class MeasurementTSExtractor implements
-			AssignerWithPeriodicWatermarks<FakeKafkaRecord> {
-		private static final long serialVersionUID = 2L;
-
-		private long currentMaxTimestamp;
-		private long lastEmittedWatermark = Long.MIN_VALUE;
-		private long lastRecordProcessingTime;
-
-		private final long maxOutOfOrderness;
-		private final long idleTimeout;
-
-		MeasurementTSExtractor(Time maxOutOfOrderness, Time idleTimeout) {
-			if (maxOutOfOrderness.toMilliseconds() < 0) {
-				throw new RuntimeException("Tried to set the maximum allowed " +
-						"lateness to " + maxOutOfOrderness +
-						". This parameter cannot be negative.");
-			}
-
-			if (idleTimeout.toMilliseconds() < 0) {
-				throw new RuntimeException("Tried to set the idle Timeout" + idleTimeout +
-						". This parameter cannot be negative.");
-			}
-
-			this.maxOutOfOrderness = maxOutOfOrderness.toMilliseconds();
-			this.idleTimeout = idleTimeout.toMilliseconds();
-			this.currentMaxTimestamp = Long.MIN_VALUE;
-		}
-
-		/**
-		 * Gets the configured out of orderness (in ms).
-		 */
-		public long getMaxOutOfOrdernessInMillis() {
-			return maxOutOfOrderness;
-		}
-
-		@Override
-		public final Watermark getCurrentWatermark() {
-
-			// if last record was processed more than the idleTimeout in the past, consider this
-			// source idle and set timestamp to current processing time
-			long currentProcessingTime = System.currentTimeMillis();
-			if (lastRecordProcessingTime < currentProcessingTime - idleTimeout) {
-				this.currentMaxTimestamp = currentProcessingTime;
-			}
-
-			long potentialWM = this.currentMaxTimestamp - maxOutOfOrderness;
-			if (potentialWM >= lastEmittedWatermark) {
-				lastEmittedWatermark = potentialWM;
-			}
-			return new Watermark(lastEmittedWatermark);
-		}
-
-		@Override
-		public final long extractTimestamp(FakeKafkaRecord element, long previousElementTimestamp) {
-			lastRecordProcessingTime = System.currentTimeMillis();
-			long timestamp = element.getTimestamp();
-			if (timestamp > currentMaxTimestamp) {
-				currentMaxTimestamp = timestamp;
-			}
-			return timestamp;
 		}
 	}
 

--- a/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution43.java
+++ b/troubleshooting/introduction/src/solution/java/com/ververica/flink/training/solutions/TroubledStreamingJobSolution43.java
@@ -6,7 +6,6 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -14,6 +13,7 @@ import org.apache.flink.streaming.api.functions.AssignerWithPeriodicWatermarks;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.util.Collector;
@@ -47,8 +47,7 @@ public class TroubledStreamingJobSolution43 {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(100);
 		env.setBufferTimeout(10);
 
@@ -75,7 +74,7 @@ public class TroubledStreamingJobSolution43 {
 
 		SingleOutputStreamOperator<WindowedMeasurements> aggregatedPerLocation = sourceStream
 				.keyBy(SimpleMeasurement::getLocation)
-				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.window(TumblingEventTimeWindows.of(Time.seconds(1)))
 				.sideOutputLateData(lateDataTag)
 				.aggregate(new MeasurementWindowAggregatingFunction(),
 						new MeasurementWindowProcessFunction())

--- a/troubleshooting/object-reuse/src/main/java/com/ververica/flink/training/exercises/ObjectReuseJob.java
+++ b/troubleshooting/object-reuse/src/main/java/com/ververica/flink/training/exercises/ObjectReuseJob.java
@@ -12,6 +12,7 @@ import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.windowing.assigners.SlidingProcessingTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.OutputTag;
@@ -25,7 +26,6 @@ import com.ververica.flink.training.provided.WeatherUtils;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
 
@@ -104,7 +104,7 @@ public class ObjectReuseJob {
 		// (3) stream with an windowed-average of the temperature (to smoothens sensor
 		//     measurements, variant B); then converted into local temperature units (°F in the US)
 		keyedTemperatureStream
-				.timeWindow(Time.of(10, TimeUnit.SECONDS), Time.of(1, TimeUnit.SECONDS))
+				.window(SlidingProcessingTimeWindows.of(Time.seconds(10), Time.seconds(1)))
 				.aggregate(new WindowAverageSensor())
 				.name("WindowAverageTemperature")
 				.uid("WindowAverageTemperature")

--- a/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/ObjectReuseJobSolution1.java
+++ b/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/ObjectReuseJobSolution1.java
@@ -12,6 +12,7 @@ import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.windowing.assigners.SlidingProcessingTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.types.DoubleValue;
 import org.apache.flink.types.FloatValue;
@@ -27,7 +28,6 @@ import com.ververica.flink.training.provided.WeatherUtils;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
 
@@ -106,7 +106,7 @@ public class ObjectReuseJobSolution1 {
 		// (3) stream with an windowed-average of the temperature (to smoothens sensor
 		//     measurements, variant B); then converted into local temperature units (°F in the US)
 		keyedTemperatureStream
-				.timeWindow(Time.of(10, TimeUnit.SECONDS), Time.of(1, TimeUnit.SECONDS))
+				.window(SlidingProcessingTimeWindows.of(Time.seconds(10), Time.seconds(1)))
 				.aggregate(new WindowAverageSensor())
 				.name("WindowAverageTemperature")
 				.uid("WindowAverageTemperature")

--- a/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/ObjectReuseJobSolution2.java
+++ b/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/ObjectReuseJobSolution2.java
@@ -12,6 +12,7 @@ import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.windowing.assigners.SlidingProcessingTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.types.DoubleValue;
 import org.apache.flink.types.FloatValue;
@@ -30,7 +31,6 @@ import com.ververica.flink.training.solutions.immutable.Sensor;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
 
@@ -110,7 +110,7 @@ public class ObjectReuseJobSolution2 {
 		// (3) stream with an windowed-average of the temperature (to smoothens sensor
 		//     measurements, variant B); then converted into local temperature units (°F in the US)
 		keyedTemperatureStream
-				.timeWindow(Time.of(10, TimeUnit.SECONDS), Time.of(1, TimeUnit.SECONDS))
+				.window(SlidingProcessingTimeWindows.of(Time.seconds(10), Time.seconds(1)))
 				.aggregate(new WindowAverageSensor())
 				.name("WindowAverageTemperature")
 				.uid("WindowAverageTemperature")

--- a/troubleshooting/state-migration/common/src/main/java/com/ververica/flink/training/exercises/StateMigrationJobBase.java
+++ b/troubleshooting/state-migration/common/src/main/java/com/ververica/flink/training/exercises/StateMigrationJobBase.java
@@ -4,7 +4,6 @@ import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -35,9 +34,6 @@ public class StateMigrationJobBase {
 		ParameterTool parameters = ParameterTool.fromArgs(args);
 
 		StreamExecutionEnvironment env = EnvironmentUtils.createConfiguredEnvironment(parameters);
-
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
 
 		//Checkpointing Configuration
 		env.enableCheckpointing(5000);

--- a/troubleshooting/throughput/src/main/java/com/ververica/flink/training/exercises/ThroughputJob.java
+++ b/troubleshooting/throughput/src/main/java/com/ververica/flink/training/exercises/ThroughputJob.java
@@ -7,11 +7,11 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.util.Collector;
@@ -25,7 +25,6 @@ import com.ververica.flink.training.common.WindowedMeasurements;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 
 import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
 import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
@@ -45,8 +44,7 @@ public class ThroughputJob {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(100);
 		env.setBufferTimeout(10);
 
@@ -72,7 +70,7 @@ public class ThroughputJob {
 
 		DataStream<WindowedMeasurements> aggregatedPerLocation = sourceStream
 				.keyBy(jsonNode -> jsonNode.get("location").asText())
-				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.window(TumblingEventTimeWindows.of(Time.seconds(1)))
 				.aggregate(new MeasurementWindowAggregatingPerLocation(),
 						new MeasurementWindowProcessFunction())
 				.name("WindowedAggregationPerLocation")
@@ -80,7 +78,7 @@ public class ThroughputJob {
 
 		DataStream<WindowedMeasurementsForArea> aggregatedPerArea = aggregatedPerLocation
 				.keyBy(m -> WindowedMeasurementsForArea.getArea(m.getLocation()))
-				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.window(TumblingEventTimeWindows.of(Time.seconds(1)))
 				.aggregate(new MeasurementWindowAggregatingPerArea());
 
 		if (isLocal(parameters)) {

--- a/troubleshooting/throughput/src/solution/java/com/ververica/flink/training/solutions/ThroughputJobSolution1.java
+++ b/troubleshooting/throughput/src/solution/java/com/ververica/flink/training/solutions/ThroughputJobSolution1.java
@@ -7,11 +7,11 @@ import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
-import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
 import org.apache.flink.util.Collector;
@@ -26,7 +26,6 @@ import com.ververica.flink.training.exercises.WindowedMeasurementsForArea;
 
 import java.io.IOException;
 import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 
 import static com.ververica.flink.training.common.EnvironmentUtils.createConfiguredEnvironment;
 import static com.ververica.flink.training.common.EnvironmentUtils.isLocal;
@@ -46,8 +45,7 @@ public class ThroughputJobSolution1 {
 
 		StreamExecutionEnvironment env = createConfiguredEnvironment(parameters);
 
-		//Time Characteristics
-		env.setStreamTimeCharacteristic(TimeCharacteristic.EventTime);
+		//Timing Configuration
 		env.getConfig().setAutoWatermarkInterval(100);
 		env.setBufferTimeout(10);
 
@@ -73,7 +71,7 @@ public class ThroughputJobSolution1 {
 
 		DataStream<WindowedMeasurements> aggregatedPerLocation = sourceStream
 				.keyBy(jsonNode -> jsonNode.get("location").asText())
-				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.window(TumblingEventTimeWindows.of(Time.seconds(1)))
 				.aggregate(new MeasurementWindowAggregatingPerLocation(),
 						new MeasurementWindowProcessFunction())
 				.name("WindowedAggregationPerLocation")
@@ -81,7 +79,7 @@ public class ThroughputJobSolution1 {
 
 		DataStream<WindowedMeasurementsForArea> aggregatedPerArea = aggregatedPerLocation
 				.keyBy(m -> WindowedMeasurementsForArea.getArea(m.getLocation()))
-				.timeWindow(Time.of(1, TimeUnit.SECONDS))
+				.window(TumblingEventTimeWindows.of(Time.seconds(1)))
 				.aggregate(new MeasurementWindowAggregatingPerArea());
 
 		if (isLocal(parameters)) {


### PR DESCRIPTION
I have

* removed TimeCharacteristic
* stopped using timeWindow
* rebased and included the commit from https://github.com/ververica/flink-training/pull/2 that reworks the troubled streaming job solutions to use WatermarkStrategy

