### PR TITLE
update Flink to 1.14.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ description = "Flink Training Exercises"
 
 allprojects {
     group = 'org.apache.flink'
-    version = '1.13-SNAPSHOT'
+    version = '1.14-SNAPSHOT'
 
     apply plugin: 'com.diffplug.spotless'
 
@@ -57,7 +57,7 @@ subprojects {
 
     ext {
         javaVersion = '1.8'
-        flinkVersion = '1.13.2'
+        flinkVersion = '1.14.0'
         scalaBinaryVersion = '2.12'
         jacksonVersion = '2.11.2'
         log4jVersion = '2.12.1'

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -12,7 +12,7 @@ java {
 dependencies {
     testApi "junit:junit:${junitVersion}"
     testApi "org.apache.flink:flink-streaming-java_${scalaBinaryVersion}:${flinkVersion}:tests"
-    testApi "org.apache.flink:flink-runtime_${scalaBinaryVersion}:${flinkVersion}:tests"
+    testApi "org.apache.flink:flink-runtime:${flinkVersion}:tests"
     testApi "org.apache.flink:flink-test-utils-junit:${flinkVersion}"
     testApi "org.apache.flink:flink-test-utils_${scalaBinaryVersion}:${flinkVersion}"
     testApi 'org.assertj:assertj-core:3.20.2'

--- a/hourly-tips/build.gradle
+++ b/hourly-tips/build.gradle
@@ -9,6 +9,6 @@ mainClassName = ext.javaExerciseClassName
 
 dependencies {
     shadow "org.apache.flink:flink-table-api-java-bridge_${scalaBinaryVersion}:${flinkVersion}"
-    shadow "org.apache.flink:flink-table-planner-blink_${scalaBinaryVersion}:${flinkVersion}"
+    shadow "org.apache.flink:flink-table-planner_${scalaBinaryVersion}:${flinkVersion}"
     shadow "org.apache.flink:flink-table-common:${flinkVersion}"
 }

--- a/troubleshooting/external-enrichment/src/provided/java/com/ververica/flink/training/provided/TemperatureClient.java
+++ b/troubleshooting/external-enrichment/src/provided/java/com/ververica/flink/training/provided/TemperatureClient.java
@@ -41,7 +41,7 @@ public class TemperatureClient {
     public void asyncGetTemperatureFor(String location, Consumer<Float> callback) {
         CompletableFuture.supplyAsync(new TemperatureSupplier(), pool)
                 .thenAcceptAsync(
-                        callback, org.apache.flink.runtime.concurrent.Executors.directExecutor());
+                        callback, org.apache.flink.util.concurrent.Executors.directExecutor());
     }
 
     private class TemperatureSupplier implements Supplier<Float> {


### PR DESCRIPTION
This updates the training exercises to use Flink 1.14.0.

Once @alibahadirzeybek has confirmed that this is working, we can merge it.