### PR TITLE
Simplify the logic of ObjectReuseJob

### DIFF
--- a/troubleshooting/object-reuse/src/main/java/com/ververica/flink/training/exercises/ObjectReuseJob.java
+++ b/troubleshooting/object-reuse/src/main/java/com/ververica/flink/training/exercises/ObjectReuseJob.java
@@ -1,21 +1,14 @@
 package com.ververica.flink.training.exercises;
 
-import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.streaming.api.datastream.DataStreamUtils;
-import org.apache.flink.streaming.api.datastream.KeyedStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
-import org.apache.flink.streaming.api.windowing.assigners.SlidingProcessingTimeWindows;
-import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.util.Collector;
-import org.apache.flink.util.OutputTag;
 
 import com.ververica.flink.training.provided.ExtendedMeasurement;
 import com.ververica.flink.training.provided.GeoUtils2;
@@ -23,7 +16,6 @@ import com.ververica.flink.training.provided.MeanGauge;
 import com.ververica.flink.training.provided.ObjectReuseExtendedMeasurementSource;
 import com.ververica.flink.training.provided.WeatherUtils;
 
-import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -51,27 +43,20 @@ public class ObjectReuseJob {
         env.enableCheckpointing(5000);
         env.getCheckpointConfig().setMinPauseBetweenCheckpoints(4000);
 
-        final OutputTag<ExtendedMeasurement> temperatureTag =
-                new OutputTag<ExtendedMeasurement>("temperature") {
-                    private static final long serialVersionUID = -3127503822430851744L;
-                };
-        final OutputTag<ExtendedMeasurement> windTag =
-                new OutputTag<ExtendedMeasurement>("wind") {
-                    private static final long serialVersionUID = 4249595595891069268L;
-                };
-
-        SingleOutputStreamOperator<ExtendedMeasurement> splitStream =
+        SingleOutputStreamOperator<ExtendedMeasurement> temperatureStream =
                 env.addSource(new ObjectReuseExtendedMeasurementSource())
                         .name("FakeMeasurementSource")
                         .uid("FakeMeasurementSource")
-                        .keyBy(ExtendedMeasurement::getSensor)
-                        .process(new SplitSensors(temperatureTag, windTag))
-                        .name("SplitSensors")
-                        .uid("SplitSensors");
+                        .filter(
+                                t ->
+                                        t.getSensor()
+                                                .getSensorType()
+                                                .equals(ExtendedMeasurement.SensorType.Temperature))
+                        .name("FilterTemperature")
+                        .uid("FilterTemperature");
 
         // (1) stream with the temperature converted into local temperature units (°F in the US)
-        splitStream
-                .getSideOutput(temperatureTag)
+        temperatureStream
                 .map(new ConvertToLocalTemperature())
                 .name("ConvertToLocalTemperature")
                 .uid("ConvertToLocalTemperature")
@@ -80,14 +65,9 @@ public class ObjectReuseJob {
                 .uid("LocalizedTemperatureSink")
                 .disableChaining();
 
-        // no need to do keyBy again; we did not change the key!
-        KeyedStream<ExtendedMeasurement, ExtendedMeasurement.Sensor> keyedTemperatureStream =
-                DataStreamUtils.reinterpretAsKeyedStream(
-                        splitStream.getSideOutput(temperatureTag), ExtendedMeasurement::getSensor);
-
         // (2) stream with an (exponentially) moving average of the temperature (smoothens sensor
         //     measurements, variant A); then converted into local temperature units (°F in the US)
-        keyedTemperatureStream
+        temperatureStream
                 .flatMap(new MovingAverageSensors())
                 .name("MovingAverageTemperature")
                 .uid("MovingAverageTemperature")
@@ -99,58 +79,7 @@ public class ObjectReuseJob {
                 .uid("LocalizedAverageTemperatureSink")
                 .disableChaining();
 
-        // (3) stream with an windowed-average of the temperature (to smoothens sensor
-        //     measurements, variant B); then converted into local temperature units (°F in the US)
-        keyedTemperatureStream
-                .window(SlidingProcessingTimeWindows.of(Time.seconds(10), Time.seconds(1)))
-                .aggregate(new WindowAverageSensor())
-                .name("WindowAverageTemperature")
-                .uid("WindowAverageTemperature")
-                .map(new ConvertToLocalTemperature())
-                .name("ConvertToLocalWindowedTemperature")
-                .uid("ConvertToLocalWindowedTemperature")
-                .addSink(new DiscardingSink<>())
-                .name("LocalizedWindowedTemperatureSink")
-                .uid("LocalizedWindowedTemperatureSink")
-                .disableChaining();
-
-        // (4) stream with the wind speed converted into local speed units (mph in the US)
-        splitStream
-                .getSideOutput(windTag)
-                .map(new ConvertToLocalWindSpeed())
-                .name("NormalizeWindSpeed")
-                .uid("NormalizeWindSpeed")
-                .addSink(new DiscardingSink<>())
-                .name("WindSink")
-                .uid("WindSink")
-                .disableChaining();
-
         env.execute(ObjectReuseJob.class.getSimpleName());
-    }
-
-    /** Splits a stream into multiple side-outputs, one for each sensor. */
-    private static class SplitSensors
-            extends KeyedProcessFunction<
-                    ExtendedMeasurement.Sensor, ExtendedMeasurement, ExtendedMeasurement> {
-        private static final long serialVersionUID = 1L;
-
-        private final EnumMap<ExtendedMeasurement.SensorType, OutputTag<ExtendedMeasurement>>
-                outputTagBySensor = new EnumMap<>(ExtendedMeasurement.SensorType.class);
-
-        SplitSensors(
-                OutputTag<ExtendedMeasurement> temperatureTag,
-                OutputTag<ExtendedMeasurement> windTag) {
-            outputTagBySensor.put(ExtendedMeasurement.SensorType.Temperature, temperatureTag);
-            outputTagBySensor.put(ExtendedMeasurement.SensorType.Wind, windTag);
-        }
-
-        @Override
-        public void processElement(
-                ExtendedMeasurement value, Context ctx, Collector<ExtendedMeasurement> out) {
-            ExtendedMeasurement.SensorType sensorType = value.getSensor().getSensorType();
-            OutputTag<ExtendedMeasurement> output = outputTagBySensor.get(sensorType);
-            ctx.output(output, value);
-        }
     }
 
     /**
@@ -192,57 +121,6 @@ public class ObjectReuseJob {
         }
     }
 
-    @SuppressWarnings("WeakerAccess")
-    public static class WindowedAggregate {
-        public double sumValue = 0.0;
-        public double sumAccuracy = 0.0;
-        public long count = 0;
-        public ExtendedMeasurement lastValue = null;
-
-        /** Constructor. */
-        public WindowedAggregate() {}
-    }
-
-    /** Aggregate function determining average sensor values and accuracies per sensor instance. */
-    private static class WindowAverageSensor
-            implements AggregateFunction<
-                    ExtendedMeasurement, WindowedAggregate, ExtendedMeasurement> {
-        @Override
-        public WindowedAggregate createAccumulator() {
-            return new WindowedAggregate();
-        }
-
-        @Override
-        public WindowedAggregate add(ExtendedMeasurement value, WindowedAggregate accumulator) {
-            accumulator.sumAccuracy += value.getMeasurement().getAccuracy();
-            accumulator.sumValue += value.getMeasurement().getValue();
-            accumulator.count++;
-            accumulator.lastValue = value;
-            return accumulator;
-        }
-
-        @Override
-        public ExtendedMeasurement getResult(WindowedAggregate accumulator) {
-            ExtendedMeasurement result = accumulator.lastValue;
-            result.getMeasurement().setValue(accumulator.sumValue / accumulator.count);
-            result.getMeasurement()
-                    .setAccuracy((float) (accumulator.sumAccuracy / accumulator.count));
-            return result;
-        }
-
-        @Override
-        public WindowedAggregate merge(WindowedAggregate a, WindowedAggregate b) {
-            a.count += b.count;
-            a.sumValue += b.sumValue;
-            a.sumAccuracy += b.sumAccuracy;
-            if (b.lastValue.getMeasurement().getTimestamp()
-                    > a.lastValue.getMeasurement().getTimestamp()) {
-                a.lastValue = b.lastValue;
-            }
-            return a;
-        }
-    }
-
     /**
      * Converts SI units to locale-dependent units, i.e. °C to °F for the US. Adds a custom metric
      * to report temperatures in the US.
@@ -279,25 +157,6 @@ public class ObjectReuseJob {
                 double normalized = WeatherUtils.celciusToFahrenheit(measurement.getValue());
                 measurement.setValue(normalized);
                 normalizedTemperatureUS.addValue(normalized);
-            }
-            return value;
-        }
-    }
-
-    /**
-     * Converts SI units to locale-dependent units, i.e. km/h to mph for the US. Adds a custom
-     * metric to report wind speeds in the US.
-     */
-    private static class ConvertToLocalWindSpeed
-            extends RichMapFunction<ExtendedMeasurement, ExtendedMeasurement> {
-        private static final long serialVersionUID = 1L;
-
-        @Override
-        public ExtendedMeasurement map(ExtendedMeasurement value) {
-            ExtendedMeasurement.Location location = value.getLocation();
-            if (GeoUtils2.isInUS(location.getLongitude(), location.getLatitude())) {
-                ExtendedMeasurement.MeasurementValue measurement = value.getMeasurement();
-                measurement.setValue(WeatherUtils.kphToMph(measurement.getValue()));
             }
             return value;
         }

--- a/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/ObjectReuseJobSolution1.java
+++ b/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/ObjectReuseJobSolution1.java
@@ -1,23 +1,16 @@
 package com.ververica.flink.training.solutions;
 
-import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.streaming.api.datastream.DataStreamUtils;
-import org.apache.flink.streaming.api.datastream.KeyedStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
-import org.apache.flink.streaming.api.windowing.assigners.SlidingProcessingTimeWindows;
-import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.types.DoubleValue;
 import org.apache.flink.types.FloatValue;
 import org.apache.flink.util.Collector;
-import org.apache.flink.util.OutputTag;
 
 import com.ververica.flink.training.provided.ExtendedMeasurement;
 import com.ververica.flink.training.provided.GeoUtils2;
@@ -25,7 +18,6 @@ import com.ververica.flink.training.provided.MeanGauge;
 import com.ververica.flink.training.provided.ObjectReuseExtendedMeasurementSource;
 import com.ververica.flink.training.provided.WeatherUtils;
 
-import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -53,27 +45,20 @@ public class ObjectReuseJobSolution1 {
         env.enableCheckpointing(5000);
         env.getCheckpointConfig().setMinPauseBetweenCheckpoints(4000);
 
-        final OutputTag<ExtendedMeasurement> temperatureTag =
-                new OutputTag<ExtendedMeasurement>("temperature") {
-                    private static final long serialVersionUID = -3127503822430851744L;
-                };
-        final OutputTag<ExtendedMeasurement> windTag =
-                new OutputTag<ExtendedMeasurement>("wind") {
-                    private static final long serialVersionUID = 4249595595891069268L;
-                };
-
-        SingleOutputStreamOperator<ExtendedMeasurement> splitStream =
+        SingleOutputStreamOperator<ExtendedMeasurement> temperatureStream =
                 env.addSource(new ObjectReuseExtendedMeasurementSource())
                         .name("FakeMeasurementSource")
                         .uid("FakeMeasurementSource")
-                        .keyBy(ExtendedMeasurement::getSensor)
-                        .process(new SplitSensors(temperatureTag, windTag))
-                        .name("SplitSensors")
-                        .uid("SplitSensors");
+                        .filter(
+                                t ->
+                                        t.getSensor()
+                                                .getSensorType()
+                                                .equals(ExtendedMeasurement.SensorType.Temperature))
+                        .name("FilterTemperature")
+                        .uid("FilterTemperature");
 
         // (1) stream with the temperature converted into local temperature units (°F in the US)
-        splitStream
-                .getSideOutput(temperatureTag)
+        temperatureStream
                 .map(new ConvertToLocalTemperature())
                 .name("ConvertToLocalTemperature")
                 .uid("ConvertToLocalTemperature")
@@ -82,14 +67,9 @@ public class ObjectReuseJobSolution1 {
                 .uid("LocalizedTemperatureSink")
                 .disableChaining();
 
-        // no need to do keyBy again; we did not change the key!
-        KeyedStream<ExtendedMeasurement, ExtendedMeasurement.Sensor> keyedTemperatureStream =
-                DataStreamUtils.reinterpretAsKeyedStream(
-                        splitStream.getSideOutput(temperatureTag), ExtendedMeasurement::getSensor);
-
         // (2) stream with an (exponentially) moving average of the temperature (smoothens sensor
         //     measurements, variant A); then converted into local temperature units (°F in the US)
-        keyedTemperatureStream
+        temperatureStream
                 .flatMap(new MovingAverageSensors())
                 .name("MovingAverageTemperature")
                 .uid("MovingAverageTemperature")
@@ -101,58 +81,7 @@ public class ObjectReuseJobSolution1 {
                 .uid("LocalizedAverageTemperatureSink")
                 .disableChaining();
 
-        // (3) stream with an windowed-average of the temperature (to smoothens sensor
-        //     measurements, variant B); then converted into local temperature units (°F in the US)
-        keyedTemperatureStream
-                .window(SlidingProcessingTimeWindows.of(Time.seconds(10), Time.seconds(1)))
-                .aggregate(new WindowAverageSensor())
-                .name("WindowAverageTemperature")
-                .uid("WindowAverageTemperature")
-                .map(new ConvertToLocalTemperature())
-                .name("ConvertToLocalWindowedTemperature")
-                .uid("ConvertToLocalWindowedTemperature")
-                .addSink(new DiscardingSink<>())
-                .name("LocalizedWindowedTemperatureSink")
-                .uid("LocalizedWindowedTemperatureSink")
-                .disableChaining();
-
-        // (4) stream with the wind speed converted into local speed units (mph in the US)
-        splitStream
-                .getSideOutput(windTag)
-                .map(new ConvertToLocalWindSpeed())
-                .name("NormalizeWindSpeed")
-                .uid("NormalizeWindSpeed")
-                .addSink(new DiscardingSink<>())
-                .name("WindSink")
-                .uid("WindSink")
-                .disableChaining();
-
         env.execute(ObjectReuseJobSolution1.class.getSimpleName());
-    }
-
-    /** Splits a stream into multiple side-outputs, one for each sensor. */
-    private static class SplitSensors
-            extends KeyedProcessFunction<
-                    ExtendedMeasurement.Sensor, ExtendedMeasurement, ExtendedMeasurement> {
-        private static final long serialVersionUID = 1L;
-
-        private final EnumMap<ExtendedMeasurement.SensorType, OutputTag<ExtendedMeasurement>>
-                outputTagBySensor = new EnumMap<>(ExtendedMeasurement.SensorType.class);
-
-        SplitSensors(
-                OutputTag<ExtendedMeasurement> temperatureTag,
-                OutputTag<ExtendedMeasurement> windTag) {
-            outputTagBySensor.put(ExtendedMeasurement.SensorType.Temperature, temperatureTag);
-            outputTagBySensor.put(ExtendedMeasurement.SensorType.Wind, windTag);
-        }
-
-        @Override
-        public void processElement(
-                ExtendedMeasurement value, Context ctx, Collector<ExtendedMeasurement> out) {
-            ExtendedMeasurement.SensorType sensorType = value.getSensor().getSensorType();
-            OutputTag<ExtendedMeasurement> output = outputTagBySensor.get(sensorType);
-            ctx.output(output, value);
-        }
     }
 
     /**
@@ -202,60 +131,6 @@ public class ObjectReuseJobSolution1 {
         }
     }
 
-    @SuppressWarnings("WeakerAccess")
-    public static class WindowedAggregate {
-        public double sumValue = 0.0;
-        public double sumAccuracy = 0.0;
-        public long count = 0;
-        public ExtendedMeasurement lastValue = null;
-
-        /** Constructor. */
-        public WindowedAggregate() {}
-    }
-
-    /** Aggregate function determining average sensor values and accuracies per sensor instance. */
-    private static class WindowAverageSensor
-            implements AggregateFunction<
-                    ExtendedMeasurement, WindowedAggregate, ExtendedMeasurement> {
-        @Override
-        public WindowedAggregate createAccumulator() {
-            return new WindowedAggregate();
-        }
-
-        @Override
-        public WindowedAggregate add(ExtendedMeasurement value, WindowedAggregate accumulator) {
-            accumulator.sumAccuracy += value.getMeasurement().getAccuracy();
-            accumulator.sumValue += value.getMeasurement().getValue();
-            accumulator.count++;
-            accumulator.lastValue = value;
-            return accumulator;
-        }
-
-        @Override
-        public ExtendedMeasurement getResult(WindowedAggregate accumulator) {
-            double avgValue = accumulator.sumValue / accumulator.count;
-            float avgAccuracy = (float) (accumulator.sumAccuracy / accumulator.count);
-            ExtendedMeasurement lastValue = accumulator.lastValue;
-            ExtendedMeasurement.MeasurementValue measurement =
-                    new ExtendedMeasurement.MeasurementValue(
-                            avgValue, avgAccuracy, lastValue.getMeasurement().getTimestamp());
-            return new ExtendedMeasurement(
-                    lastValue.getSensor(), lastValue.getLocation(), measurement);
-        }
-
-        @Override
-        public WindowedAggregate merge(WindowedAggregate a, WindowedAggregate b) {
-            a.count += b.count;
-            a.sumValue += b.sumValue;
-            a.sumAccuracy += b.sumAccuracy;
-            if (b.lastValue.getMeasurement().getTimestamp()
-                    > a.lastValue.getMeasurement().getTimestamp()) {
-                a.lastValue = b.lastValue;
-            }
-            return a;
-        }
-    }
-
     /**
      * Converts SI units to locale-dependent units, i.e. °C to °F for the US. Adds a custom metric
      * to report temperatures in the US.
@@ -296,33 +171,6 @@ public class ObjectReuseJobSolution1 {
                                 normalized, measurement.getAccuracy(), measurement.getTimestamp());
 
                 normalizedTemperatureUS.addValue(normalized);
-                return new ExtendedMeasurement(
-                        value.getSensor(), value.getLocation(), localizedMeasurement);
-            } else {
-                return value;
-            }
-        }
-    }
-
-    /**
-     * Converts SI units to locale-dependent units, i.e. km/h to mph for the US. Adds a custom
-     * metric to report wind speeds in the US.
-     */
-    private static class ConvertToLocalWindSpeed
-            extends RichMapFunction<ExtendedMeasurement, ExtendedMeasurement> {
-        private static final long serialVersionUID = 1L;
-
-        @Override
-        public ExtendedMeasurement map(ExtendedMeasurement value) {
-            ExtendedMeasurement.Location location = value.getLocation();
-            if (GeoUtils2.isInUS(location.getLongitude(), location.getLatitude())) {
-                ExtendedMeasurement.MeasurementValue measurement = value.getMeasurement();
-                double normalized = WeatherUtils.kphToMph(measurement.getValue());
-
-                ExtendedMeasurement.MeasurementValue localizedMeasurement =
-                        new ExtendedMeasurement.MeasurementValue(
-                                normalized, measurement.getAccuracy(), measurement.getTimestamp());
-
                 return new ExtendedMeasurement(
                         value.getSensor(), value.getLocation(), localizedMeasurement);
             } else {

--- a/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/ObjectReuseJobSolution1.java
+++ b/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/ObjectReuseJobSolution1.java
@@ -8,8 +8,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
-import org.apache.flink.types.DoubleValue;
-import org.apache.flink.types.FloatValue;
 import org.apache.flink.util.Collector;
 
 import com.ververica.flink.training.provided.ExtendedMeasurement;
@@ -99,7 +97,7 @@ public class ObjectReuseJobSolution1 {
             extends RichFlatMapFunction<ExtendedMeasurement, ExtendedMeasurement> {
         private static final long serialVersionUID = 1L;
 
-        private final Map<ExtendedMeasurement.Sensor, Tuple2<FloatValue, DoubleValue>> lastAverage =
+        private final Map<ExtendedMeasurement.Sensor, Tuple2<Float, Double>> lastAverage =
                 new HashMap<>();
 
         @Override
@@ -107,26 +105,23 @@ public class ObjectReuseJobSolution1 {
             ExtendedMeasurement.Sensor sensor = value.getSensor();
             ExtendedMeasurement.MeasurementValue measurement = value.getMeasurement();
 
-            Tuple2<FloatValue, DoubleValue> last = lastAverage.get(sensor);
+            Tuple2<Float, Double> last = lastAverage.get(sensor);
             if (last != null) {
-                last.f0.setValue((last.f0.getValue() + measurement.getAccuracy()) / 2.0f);
-                last.f1.setValue((last.f1.getValue() + measurement.getValue()) / 2.0);
+                float newAccuracy = (last.f0 + measurement.getAccuracy()) / 2.0f;
+                double newValue = (last.f1 + measurement.getValue()) / 2.0;
 
                 ExtendedMeasurement.MeasurementValue averageMeasurement =
                         new ExtendedMeasurement.MeasurementValue(
-                                last.f1.getValue(), last.f0.getValue(), measurement.getTimestamp());
+                                newValue, newAccuracy, measurement.getTimestamp());
                 ExtendedMeasurement forward =
                         new ExtendedMeasurement(
                                 value.getSensor(), value.getLocation(), averageMeasurement);
 
-                // do not forward the first value (it only stands alone)
                 out.collect(forward);
             } else {
+                // do not forward the first value (it only stands alone)
                 lastAverage.put(
-                        sensor,
-                        Tuple2.of(
-                                new FloatValue(measurement.getAccuracy()),
-                                new DoubleValue(measurement.getValue())));
+                        sensor, Tuple2.of(measurement.getAccuracy(), measurement.getValue()));
             }
         }
     }

--- a/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/ObjectReuseJobSolution2.java
+++ b/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/ObjectReuseJobSolution2.java
@@ -8,8 +8,6 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
-import org.apache.flink.types.DoubleValue;
-import org.apache.flink.types.FloatValue;
 import org.apache.flink.util.Collector;
 
 import com.ververica.flink.training.provided.GeoUtils2;
@@ -105,33 +103,29 @@ public class ObjectReuseJobSolution2 {
             extends RichFlatMapFunction<ExtendedMeasurement, ExtendedMeasurement> {
         private static final long serialVersionUID = 1L;
 
-        private final Map<Sensor, Tuple2<FloatValue, DoubleValue>> lastAverage = new HashMap<>();
+        private final Map<Sensor, Tuple2<Float, Double>> lastAverage = new HashMap<>();
 
         @Override
         public void flatMap(ExtendedMeasurement value, Collector<ExtendedMeasurement> out) {
             Sensor sensor = value.getSensor();
             MeasurementValue measurement = value.getMeasurement();
 
-            Tuple2<FloatValue, DoubleValue> last = lastAverage.get(sensor);
+            Tuple2<Float, Double> last = lastAverage.get(sensor);
             if (last != null) {
-                last.f0.setValue((last.f0.getValue() + measurement.getAccuracy()) / 2.0f);
-                last.f1.setValue((last.f1.getValue() + measurement.getValue()) / 2.0);
+                float newAccuracy = (last.f0 + measurement.getAccuracy()) / 2.0f;
+                double newValue = (last.f1 + measurement.getValue()) / 2.0;
 
                 MeasurementValue averageMeasurement =
-                        new MeasurementValue(
-                                last.f1.getValue(), last.f0.getValue(), measurement.getTimestamp());
+                        new MeasurementValue(newValue, newAccuracy, measurement.getTimestamp());
                 ExtendedMeasurement forward =
                         new ExtendedMeasurement(
                                 value.getSensor(), value.getLocation(), averageMeasurement);
 
-                // do not forward the first value (it only stands alone)
                 out.collect(forward);
             } else {
+                // do not forward the first value (it only stands alone)
                 lastAverage.put(
-                        sensor,
-                        Tuple2.of(
-                                new FloatValue(measurement.getAccuracy()),
-                                new DoubleValue(measurement.getValue())));
+                        sensor, Tuple2.of(measurement.getAccuracy(), measurement.getValue()));
             }
         }
     }

--- a/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/ObjectReuseJobSolution2.java
+++ b/troubleshooting/object-reuse/src/solution/java/com/ververica/flink/training/solutions/ObjectReuseJobSolution2.java
@@ -1,23 +1,16 @@
 package com.ververica.flink.training.solutions;
 
-import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.functions.RichFlatMapFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.utils.ParameterTool;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.streaming.api.datastream.DataStreamUtils;
-import org.apache.flink.streaming.api.datastream.KeyedStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.KeyedProcessFunction;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
-import org.apache.flink.streaming.api.windowing.assigners.SlidingProcessingTimeWindows;
-import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.types.DoubleValue;
 import org.apache.flink.types.FloatValue;
 import org.apache.flink.util.Collector;
-import org.apache.flink.util.OutputTag;
 
 import com.ververica.flink.training.provided.GeoUtils2;
 import com.ververica.flink.training.provided.MeanGauge;
@@ -28,7 +21,6 @@ import com.ververica.flink.training.solutions.immutable.MeasurementValue;
 import com.ververica.flink.training.solutions.immutable.ObjectReuseExtendedMeasurementSource;
 import com.ververica.flink.training.solutions.immutable.Sensor;
 
-import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -59,27 +51,20 @@ public class ObjectReuseJobSolution2 {
         env.enableCheckpointing(5000);
         env.getCheckpointConfig().setMinPauseBetweenCheckpoints(4000);
 
-        final OutputTag<ExtendedMeasurement> temperatureTag =
-                new OutputTag<ExtendedMeasurement>("temperature") {
-                    private static final long serialVersionUID = -3127503822430851744L;
-                };
-        final OutputTag<ExtendedMeasurement> windTag =
-                new OutputTag<ExtendedMeasurement>("wind") {
-                    private static final long serialVersionUID = 4249595595891069268L;
-                };
-
-        SingleOutputStreamOperator<ExtendedMeasurement> splitStream =
+        SingleOutputStreamOperator<ExtendedMeasurement> temperatureStream =
                 env.addSource(new ObjectReuseExtendedMeasurementSource())
                         .name("FakeMeasurementSource")
                         .uid("FakeMeasurementSource")
-                        .keyBy(ExtendedMeasurement::getSensor)
-                        .process(new SplitSensors(temperatureTag, windTag))
-                        .name("SplitSensors")
-                        .uid("SplitSensors");
+                        .filter(
+                                t ->
+                                        t.getSensor()
+                                                .getSensorType()
+                                                .equals(Sensor.SensorType.Temperature))
+                        .name("FilterTemperature")
+                        .uid("FilterTemperature");
 
         // (1) stream with the temperature converted into local temperature units (°F in the US)
-        splitStream
-                .getSideOutput(temperatureTag)
+        temperatureStream
                 .map(new ConvertToLocalTemperature())
                 .name("ConvertToLocalTemperature")
                 .uid("ConvertToLocalTemperature")
@@ -88,14 +73,9 @@ public class ObjectReuseJobSolution2 {
                 .uid("LocalizedTemperatureSink")
                 .disableChaining();
 
-        // no need to do keyBy again; we did not change the key!
-        KeyedStream<ExtendedMeasurement, Sensor> keyedTemperatureStream =
-                DataStreamUtils.reinterpretAsKeyedStream(
-                        splitStream.getSideOutput(temperatureTag), ExtendedMeasurement::getSensor);
-
         // (2) stream with an (exponentially) moving average of the temperature (smoothens sensor
         //     measurements, variant A); then converted into local temperature units (°F in the US)
-        keyedTemperatureStream
+        temperatureStream
                 .flatMap(new MovingAverageSensors())
                 .name("MovingAverageTemperature")
                 .uid("MovingAverageTemperature")
@@ -107,57 +87,7 @@ public class ObjectReuseJobSolution2 {
                 .uid("LocalizedAverageTemperatureSink")
                 .disableChaining();
 
-        // (3) stream with an windowed-average of the temperature (to smoothens sensor
-        //     measurements, variant B); then converted into local temperature units (°F in the US)
-        keyedTemperatureStream
-                .window(SlidingProcessingTimeWindows.of(Time.seconds(10), Time.seconds(1)))
-                .aggregate(new WindowAverageSensor())
-                .name("WindowAverageTemperature")
-                .uid("WindowAverageTemperature")
-                .map(new ConvertToLocalTemperature())
-                .name("ConvertToLocalWindowedTemperature")
-                .uid("ConvertToLocalWindowedTemperature")
-                .addSink(new DiscardingSink<>())
-                .name("LocalizedWindowedTemperatureSink")
-                .uid("LocalizedWindowedTemperatureSink")
-                .disableChaining();
-
-        // (4) stream with the wind speed converted into local speed units (mph in the US)
-        splitStream
-                .getSideOutput(windTag)
-                .map(new ConvertToLocalWindSpeed())
-                .name("NormalizeWindSpeed")
-                .uid("NormalizeWindSpeed")
-                .addSink(new DiscardingSink<>())
-                .name("WindSink")
-                .uid("WindSink")
-                .disableChaining();
-
         env.execute(ObjectReuseJobSolution2.class.getSimpleName());
-    }
-
-    /** Splits a stream into multiple side-outputs, one for each sensor. */
-    private static class SplitSensors
-            extends KeyedProcessFunction<Sensor, ExtendedMeasurement, ExtendedMeasurement> {
-        private static final long serialVersionUID = 1L;
-
-        private final EnumMap<Sensor.SensorType, OutputTag<ExtendedMeasurement>> outputTagBySensor =
-                new EnumMap<>(Sensor.SensorType.class);
-
-        SplitSensors(
-                OutputTag<ExtendedMeasurement> temperatureTag,
-                OutputTag<ExtendedMeasurement> windTag) {
-            outputTagBySensor.put(Sensor.SensorType.Temperature, temperatureTag);
-            outputTagBySensor.put(Sensor.SensorType.Wind, windTag);
-        }
-
-        @Override
-        public void processElement(
-                ExtendedMeasurement value, Context ctx, Collector<ExtendedMeasurement> out) {
-            Sensor.SensorType sensorType = value.getSensor().getSensorType();
-            OutputTag<ExtendedMeasurement> output = outputTagBySensor.get(sensorType);
-            ctx.output(output, value);
-        }
     }
 
     /**
@@ -206,60 +136,6 @@ public class ObjectReuseJobSolution2 {
         }
     }
 
-    @SuppressWarnings("WeakerAccess")
-    public static class WindowedAggregate {
-        public double sumValue = 0.0;
-        public double sumAccuracy = 0.0;
-        public long count = 0;
-        public ExtendedMeasurement lastValue = null;
-
-        /** Constructor. */
-        public WindowedAggregate() {}
-    }
-
-    /** Aggregate function determining average sensor values and accuracies per sensor instance. */
-    private static class WindowAverageSensor
-            implements AggregateFunction<
-                    ExtendedMeasurement, WindowedAggregate, ExtendedMeasurement> {
-        @Override
-        public WindowedAggregate createAccumulator() {
-            return new WindowedAggregate();
-        }
-
-        @Override
-        public WindowedAggregate add(ExtendedMeasurement value, WindowedAggregate accumulator) {
-            accumulator.sumAccuracy += value.getMeasurement().getAccuracy();
-            accumulator.sumValue += value.getMeasurement().getValue();
-            accumulator.count++;
-            accumulator.lastValue = value;
-            return accumulator;
-        }
-
-        @Override
-        public ExtendedMeasurement getResult(WindowedAggregate accumulator) {
-            double avgValue = accumulator.sumValue / accumulator.count;
-            float avgAccuracy = (float) (accumulator.sumAccuracy / accumulator.count);
-            ExtendedMeasurement lastValue = accumulator.lastValue;
-            MeasurementValue measurement =
-                    new MeasurementValue(
-                            avgValue, avgAccuracy, lastValue.getMeasurement().getTimestamp());
-            return new ExtendedMeasurement(
-                    lastValue.getSensor(), lastValue.getLocation(), measurement);
-        }
-
-        @Override
-        public WindowedAggregate merge(WindowedAggregate a, WindowedAggregate b) {
-            a.count += b.count;
-            a.sumValue += b.sumValue;
-            a.sumAccuracy += b.sumAccuracy;
-            if (b.lastValue.getMeasurement().getTimestamp()
-                    > a.lastValue.getMeasurement().getTimestamp()) {
-                a.lastValue = b.lastValue;
-            }
-            return a;
-        }
-    }
-
     /**
      * Converts SI units to locale-dependent units, i.e. °C to °F for the US. Adds a custom metric
      * to report temperatures in the US.
@@ -300,33 +176,6 @@ public class ObjectReuseJobSolution2 {
                                 normalized, measurement.getAccuracy(), measurement.getTimestamp());
 
                 normalizedTemperatureUS.addValue(normalized);
-                return new ExtendedMeasurement(
-                        value.getSensor(), value.getLocation(), localizedMeasurement);
-            } else {
-                return value;
-            }
-        }
-    }
-
-    /**
-     * Converts SI units to locale-dependent units, i.e. km/h to mph for the US. Adds a custom
-     * metric to report wind speeds in the US.
-     */
-    private static class ConvertToLocalWindSpeed
-            extends RichMapFunction<ExtendedMeasurement, ExtendedMeasurement> {
-        private static final long serialVersionUID = 1L;
-
-        @Override
-        public ExtendedMeasurement map(ExtendedMeasurement value) {
-            Location location = value.getLocation();
-            if (GeoUtils2.isInUS(location.getLongitude(), location.getLatitude())) {
-                MeasurementValue measurement = value.getMeasurement();
-                double normalized = WeatherUtils.kphToMph(measurement.getValue());
-
-                MeasurementValue localizedMeasurement =
-                        new MeasurementValue(
-                                normalized, measurement.getAccuracy(), measurement.getTimestamp());
-
                 return new ExtendedMeasurement(
                         value.getSensor(), value.getLocation(), localizedMeasurement);
             } else {


### PR DESCRIPTION
Previous ObjectReuseJob is a bit too complex for participants.
We should drop some complex statements to let participants focus on understanding points below:

1.     how to ensure job correctness when object reuse is enabled
2.     how to improve the performance by changing serializer

This is a forward-port of https://github.com/ververica/flink-training-troubleshooting/pull/6. I adapted the training dashboard to remove a now unnecessary graph and checked that you can still see the same results from enabling object reuse (too high temperatures)